### PR TITLE
Add autovacuum tuning and multi-database support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            bertrand73/pgassistant:3.4.5
+            bertrand73/pgassistant:3.5.0
             bertrand73/pgassistant:latest
           platforms: linux/amd64,linux/arm64
           no-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [3.5.0] - 2026-07-28
+
+## Improvements
+
+- Multi database mode : added a bouton to list and analyse all databases in your postgres instance
+
+- Autovacuum tuning : Analyse all tables and autovacuum parameters, executing analyse, vacuum and alter table
+
 ## [3.4.5] - 2026-07-26
 
 ## Bug fixes

--- a/advisor_enriched.yml
+++ b/advisor_enriched.yml
@@ -2470,6 +2470,317 @@ recommendations:
           schema_name,
           table_name;        
 
+  - id: table_autovacuum_maintenance_flagged
+    label: Table autovacuum maintenance flagged
+    source: pgassistant
+    team: OPS
+    category_id: MAINTENANCE
+    object_type: TABLE
+    outcome_id: OPERABILITY
+    advisor_group: AUTOVACUUM_HEALTH
+    enabled_by_default: false
+    manual_review_required: true
+    confidence: 85
+    impact: 75
+    effort: 25
+    risk_level: MEDIUM
+    action_type: REVIEW_ONLY
+    action_safety: MANUAL_REVIEW_RECOMMENDED
+    requires_lock: false
+    requires_maintenance_window: false
+    can_generate_sql: false
+    can_auto_apply: false
+    tags:
+      - pgassistant
+      - autovacuum
+      - analyze
+      - vacuum
+      - maintenance
+    why_it_matters: >
+      Flags user tables that require ANALYZE when statistics are missing or older than
+      the configured threshold, and VACUUM only when dead tuple pressure is significant
+      relative to table size. Manual ANALYZE counts the same as autovacuum analyze.
+    pgassistant_parameters:
+      stale_days:
+        default: 7
+        description: Maximum age in days since last manual or auto analyze.
+      min_table_size_bytes:
+        default: 1048576
+        description: Ignore tables smaller than this size in bytes.
+      dead_tuple_min_absolute:
+        default: 10000
+        description: Minimum dead tuples before vacuum pressure is considered.
+      dead_tuple_min_ratio:
+        default: 0.05
+        description: Minimum dead/live ratio before vacuum pressure is considered.
+    fix_strategy: >
+      Refresh statistics with ANALYZE when last analyze or autoanalyze is older than
+      stale_days. Run VACUUM only when dead tuples are material versus table size; an old
+      vacuum timestamp alone is not enough if dead tuple pressure is low.
+    result_mapping:
+      object_id: object_id
+      schema_name: schema_name
+      table_name: table_name
+      object_name: object_name
+      recommendation_note: recommendation_note
+      recommendation_level: pga_recommendation_level
+    sql: |
+        WITH params AS (
+            SELECT
+                {{stale_days}}::int AS stale_days,
+                {{min_table_size_bytes}}::bigint AS min_table_size_bytes
+        ),
+        base AS (
+            SELECT
+                s.schemaname,
+                s.relname,
+                s.relid,
+                s.n_live_tup,
+                s.n_dead_tup,
+                s.n_mod_since_analyze,
+                s.last_analyze,
+                s.last_autoanalyze,
+                s.last_vacuum,
+                s.last_autovacuum,
+                pg_total_relation_size(s.relid) AS total_size_bytes,
+                pg_relation_size(s.relid) AS table_size_bytes,
+                GREATEST(s.last_analyze, s.last_autoanalyze) AS last_any_analyze,
+                GREATEST(s.last_vacuum, s.last_autovacuum) AS last_any_vacuum
+            FROM pg_stat_user_tables AS s
+            CROSS JOIN params AS p
+            WHERE pg_relation_size(s.relid) >= p.min_table_size_bytes
+        ),
+        enriched AS (
+            SELECT
+                b.*,
+                COALESCE(
+                    b.n_mod_since_analyze::numeric / NULLIF(b.n_live_tup, 0),
+                    0
+                ) AS modified_since_analyze_ratio,
+                COALESCE(
+                    b.n_dead_tup::numeric / NULLIF(b.n_live_tup + b.n_dead_tup, 0),
+                    0
+                ) AS dead_tuple_ratio,
+                (b.last_any_analyze IS NULL) AS never_analyzed,
+                (
+                    b.last_any_analyze IS NOT NULL
+                    AND b.last_any_analyze < now() - ((SELECT stale_days FROM params) || ' days')::interval
+                ) AS stale_analyze,
+                (b.last_any_vacuum IS NULL) AS never_vacuumed,
+                (
+                    b.last_any_vacuum IS NOT NULL
+                    AND b.last_any_vacuum < now() - ((SELECT stale_days FROM params) || ' days')::interval
+                ) AS stale_vacuum,
+                (
+                    b.n_dead_tup >= 10000
+                    AND COALESCE(
+                        b.n_dead_tup::numeric / NULLIF(b.n_live_tup, 0),
+                        0
+                    ) >= 0.05
+                )
+                OR b.n_dead_tup >= 100000
+                OR (
+                    b.table_size_bytes >= 1024 * 1024 * 1024
+                    AND COALESCE(
+                        b.n_dead_tup::numeric / NULLIF(b.n_live_tup, 0),
+                        0
+                    ) >= 0.20
+                ) AS needs_vacuum_pressure,
+                CASE
+                    WHEN b.last_any_analyze IS NOT NULL
+                    THEN EXTRACT(EPOCH FROM (now() - b.last_any_analyze)) / 86400.0
+                END AS stats_age_days,
+                CASE
+                    WHEN b.last_any_vacuum IS NOT NULL
+                    THEN EXTRACT(EPOCH FROM (now() - b.last_any_vacuum)) / 86400.0
+                END AS vacuum_age_days
+            FROM base AS b
+        ),
+        flagged AS (
+            SELECT
+                e.*,
+                (e.never_vacuumed AND e.needs_vacuum_pressure) AS vacuum_issue_never,
+                (e.stale_vacuum AND e.needs_vacuum_pressure) AS vacuum_issue_stale
+            FROM enriched AS e
+            WHERE
+                e.never_analyzed
+                OR e.stale_analyze
+                OR (e.never_vacuumed AND e.needs_vacuum_pressure)
+                OR (e.stale_vacuum AND e.needs_vacuum_pressure)
+        ),
+        scored AS (
+            SELECT
+                relid AS object_id,
+                schemaname AS schema_name,
+                relname AS table_name,
+                schemaname || '.' || relname AS object_name,
+                total_size_bytes,
+                pg_size_pretty(total_size_bytes) AS total_size_pretty,
+                table_size_bytes,
+                pg_size_pretty(table_size_bytes) AS table_size_pretty,
+                n_live_tup,
+                n_dead_tup,
+                n_mod_since_analyze,
+                ROUND(modified_since_analyze_ratio * 100, 2) AS modified_since_analyze_pct,
+                ROUND(dead_tuple_ratio * 100, 2) AS dead_tuple_pct,
+                needs_vacuum_pressure,
+                last_analyze,
+                last_autoanalyze,
+                last_vacuum,
+                last_autovacuum,
+                last_any_analyze,
+                last_any_vacuum,
+                ROUND(stats_age_days, 1) AS stats_age_days,
+                ROUND(vacuum_age_days, 1) AS vacuum_age_days,
+                modified_since_analyze_ratio,
+                never_analyzed,
+                stale_analyze,
+                vacuum_issue_never AS never_vacuumed,
+                vacuum_issue_stale AS stale_vacuum,
+                ARRAY_REMOVE(
+                    ARRAY[
+                        CASE WHEN never_analyzed THEN 'never_analyzed' END,
+                        CASE WHEN stale_analyze THEN 'stale_analyze' END,
+                        CASE WHEN vacuum_issue_never THEN 'never_vacuumed' END,
+                        CASE WHEN vacuum_issue_stale THEN 'stale_vacuum' END
+                    ],
+                    NULL
+                ) AS issue_types,
+                CASE
+                    WHEN never_analyzed THEN 'HIGH'
+                    WHEN never_vacuumed AND n_dead_tup >= 100000 THEN 'HIGH'
+                    WHEN stale_analyze
+                         AND modified_since_analyze_ratio > 0.20 THEN 'HIGH'
+                    WHEN stale_vacuum
+                         AND n_dead_tup >= GREATEST(10000, n_live_tup * 0.05) THEN 'HIGH'
+                    WHEN stale_analyze OR never_vacuumed OR stale_vacuum THEN 'MEDIUM'
+                    ELSE 'LOW'
+                END AS pga_recommendation_level,
+                trim(both ' ' FROM concat_ws(
+                    ' ',
+                    CASE
+                        WHEN never_analyzed
+                        THEN 'No manual or auto analyze recorded on this table.'
+                        WHEN stale_analyze
+                        THEN 'Last analyze or autoanalyze is older than the configured threshold.'
+                        ELSE NULL
+                    END,
+                    CASE
+                        WHEN vacuum_issue_never
+                        THEN 'Vacuum/autovacuum never ran and dead tuple pressure is significant.'
+                        WHEN vacuum_issue_stale
+                        THEN 'Last vacuum/autovacuum is old and dead tuple pressure is significant.'
+                        ELSE NULL
+                    END
+                )) AS recommendation_note
+            FROM flagged
+        )
+        SELECT *
+        FROM scored
+        WHERE pga_recommendation_level IN ('HIGH', 'MEDIUM', 'LOW')
+        ORDER BY
+            CASE pga_recommendation_level
+                WHEN 'HIGH' THEN 3
+                WHEN 'MEDIUM' THEN 2
+                ELSE 1
+            END DESC,
+            table_size_bytes DESC,
+            schema_name,
+            table_name;
+
+  - id: table_autovacuum_cluster_load
+    label: Cluster autovacuum load snapshot
+    source: pgassistant
+    team: OPS
+    category_id: MAINTENANCE
+    object_type: DATABASE
+    outcome_id: OPERABILITY
+    advisor_group: AUTOVACUUM_HEALTH
+    enabled_by_default: false
+    manual_review_required: true
+    confidence: 90
+    impact: 70
+    effort: 10
+    risk_level: LOW
+    action_type: REVIEW_ONLY
+    action_safety: MANUAL_REVIEW_RECOMMENDED
+    requires_lock: false
+    requires_maintenance_window: false
+    can_generate_sql: false
+    can_auto_apply: false
+    tags:
+      - pgassistant
+      - autovacuum
+      - cluster
+      - maintenance
+    why_it_matters: >
+      Aggregates cluster-wide dead tuple pressure, autovacuum worker activity, and
+      current autovacuum-related settings for global tuning proposals.
+    result_mapping:
+      user_table_count: user_table_count
+      total_dead_tuples: total_dead_tuples
+      active_autovacuum_workers: active_autovacuum_workers
+    sql: |
+        WITH table_stats AS (
+            SELECT
+                COUNT(*)::bigint AS user_table_count,
+                COALESCE(SUM(n_dead_tup), 0)::bigint AS total_dead_tuples,
+                COALESCE(SUM(n_live_tup), 0)::bigint AS total_live_tuples,
+                COUNT(*) FILTER (
+                    WHERE n_dead_tup >= 10000
+                      AND n_dead_tup::numeric / NULLIF(n_live_tup, 0) >= 0.05
+                )::bigint AS high_dead_pressure_tables,
+                COUNT(*) FILTER (
+                    WHERE GREATEST(last_vacuum, last_autovacuum) IS NULL
+                )::bigint AS never_vacuumed_tables,
+                COUNT(*) FILTER (
+                    WHERE GREATEST(last_analyze, last_autoanalyze) IS NULL
+                )::bigint AS never_analyzed_tables
+            FROM pg_stat_user_tables
+        ),
+        worker_stats AS (
+            SELECT COUNT(*)::int AS active_autovacuum_workers
+            FROM pg_stat_activity
+            WHERE backend_type = 'autovacuum worker'
+        ),
+        settings AS (
+            SELECT jsonb_object_agg(
+                name,
+                jsonb_build_object(
+                    'setting', setting,
+                    'unit', unit,
+                    'context', context,
+                    'boot_val', boot_val
+                )
+            ) AS values
+            FROM pg_settings
+            WHERE name IN (
+                'autovacuum',
+                'autovacuum_max_workers',
+                'autovacuum_naptime',
+                'autovacuum_vacuum_scale_factor',
+                'autovacuum_vacuum_threshold',
+                'autovacuum_analyze_scale_factor',
+                'autovacuum_analyze_threshold',
+                'autovacuum_vacuum_cost_delay',
+                'autovacuum_vacuum_cost_limit',
+                'log_autovacuum_min_duration',
+                'max_worker_processes'
+            )
+        )
+        SELECT
+            ts.user_table_count,
+            ts.total_dead_tuples,
+            ts.total_live_tuples,
+            ts.high_dead_pressure_tables,
+            ts.never_vacuumed_tables,
+            ts.never_analyzed_tables,
+            ws.active_autovacuum_workers,
+            s.values AS autovacuum_settings
+        FROM table_stats AS ts
+        CROSS JOIN worker_stats AS ws
+        CROSS JOIN settings AS s;
+
   - id: long_running_transactions
     label: Abnormally long-running transaction
     source: maintenance_checks

--- a/apps/home/alalyze_advisor_helpers.py
+++ b/apps/home/alalyze_advisor_helpers.py
@@ -549,7 +549,7 @@ def parse_index_columns(indexdef: str) -> List[str]:
 # pg_stat_statements context
 # --------------------------------------------------------------------
 
-def load_query_stats(con, queryid: int | str) -> Optional[QueryStats]:
+def load_query_stats(con, queryid: int | str, database_name: str = "") -> Optional[QueryStats]:
     """Load pg_stat_statements counters for the analyzed query ID."""
     sql = """
         SELECT
@@ -570,6 +570,13 @@ def load_query_stats(con, queryid: int | str) -> Optional[QueryStats]:
         WHERE queryid::text = %s
         LIMIT 1
     """
+    if not database_name:
+        with con.cursor() as cur:
+            cur.execute("SELECT current_database()")
+            row = cur.fetchone()
+            database_name = row[0] if row else ""
+
+    sql = database.prepare_pgss_sql(sql, con, database_name)
 
     with con.cursor() as cur:
         cur.execute(sql, (str(queryid),))

--- a/apps/home/analyze_advisor.py
+++ b/apps/home/analyze_advisor.py
@@ -51,7 +51,10 @@ def analyze_plan_for_safe_indexes(
             group_by_findings=group_by_findings,
         )
 
-        query_stats = helpers.load_query_stats(con, queryid) if queryid is not None else None
+        db_name = database.get_resolved_database_name(db_config)
+        query_stats = (
+            helpers.load_query_stats(con, queryid, db_name) if queryid is not None else None
+        )
 
         recommendations: List[helpers.Recommendation] = []
 

--- a/apps/home/database.py
+++ b/apps/home/database.py
@@ -335,25 +335,61 @@ def db_exec(conn, sql):
     cursor = conn.cursor()
     cursor.execute(sql)
 
+def format_sql_execution_output(cursor, notices: list[str] | None = None) -> str:
+    """Build a human-readable command output from result rows and PG notices."""
+    parts: list[str] = []
+
+    if cursor is not None and cursor.description:
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        if columns:
+            parts.append(" | ".join(str(column) for column in columns))
+            parts.append("-|-".join("-" * max(len(str(column)), 1) for column in columns))
+        for row in rows:
+            parts.append(" | ".join("" if value is None else str(value) for value in row))
+
+    for notice in notices or []:
+        cleaned = str(notice or "").strip()
+        if cleaned:
+            parts.append(cleaned)
+
+    if cursor is not None and cursor.rowcount >= 0 and not cursor.description:
+        parts.append(f"Rows affected: {cursor.rowcount}")
+
+    return "\n".join(parts).strip()
+
+
 def db_exec_recommandation(conn, sql):
     """
-    Execute a non-SELECT SQL clause on the given PostgreSQL connection.
-    
-    :param conn: The active psycopg2 connection object.
-    :param sql: The SQL clause to execute.
-    :return: A success message or error message.
+    Execute a SQL clause on the given PostgreSQL connection.
+
+    Returns success metadata plus any server notices (for example VACUUM VERBOSE)
+    or result rows (for example SELECT pg_reload_conf()).
     """
     sql = '/* launched by pgAssistant */ ' + sql
+    cursor = None
     try:
         conn.set_session(autocommit=True)
+        if hasattr(conn, "notices"):
+            conn.notices.clear()
+
         cursor = conn.cursor()
         cursor.execute(sql)
-        conn.commit()  
-        return {"success": True, "message": f"SQL executed successfully: {sql}"}
+
+        notices = list(getattr(conn, "notices", []) or [])
+        output = format_sql_execution_output(cursor, notices)
+        message = output or "Command completed successfully."
+
+        return {
+            "success": True,
+            "message": message,
+            "output": output,
+        }
     except Exception as e:
         return {"success": False, "error": str(e)}
     finally:
-        cursor.close()
+        if cursor is not None:
+            cursor.close()
 
 def get_json_cursor(conn):
     """

--- a/apps/home/database.py
+++ b/apps/home/database.py
@@ -67,36 +67,79 @@ def _add_default_uri_param(dsn: str, param_name: str, param_value: str) -> str:
     return urlunparse(parsed._replace(query=new_query))
 
 
+
+
+def is_multi_db(db_config) -> bool:
+    value = db_config.get("multi_db")
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def normalize_db_config(db_config) -> dict:
+    """Return a plain dict from Flask session or mapping objects."""
+    if db_config is None:
+        return {}
+    if hasattr(db_config, "items"):
+        return {key: db_config.get(key) for key in db_config}
+    return dict(db_config)
+
+
+def get_resolved_database_name(db_config) -> str:
+    """Database name after multi-db active_db resolution."""
+    cfg = resolve_db_config(normalize_db_config(db_config))
+    return (cfg.get("db_name") or "").strip()
+
+
+def _quote_sql_literal(value: str) -> str:
+    return "'" + (value or "").replace("'", "''") + "'"
+
+
+def resolve_db_config(db_config):
+    """Return a connection config, honoring active_db in multi-database mode."""
+    if db_config is None:
+        return db_config
+    cfg = normalize_db_config(db_config)
+    if not is_multi_db(cfg):
+        return cfg
+    active_db = (cfg.get("active_db") or cfg.get("db_name") or "").strip()
+    if not active_db:
+        return cfg
+    cfg["db_name"] = active_db
+    uri = (cfg.get("db_uri") or "").strip()
+    if uri:
+        cfg["db_uri"] = _uri_with_database(uri, active_db)
+    return cfg
+
+
+def _uri_with_database(uri: str, database_name: str) -> str:
+    database_name = (database_name or "").strip()
+    uri = (uri or "").strip()
+    if not uri or not database_name:
+        return uri
+    if not re.match(r"^postgres(ql)?://", uri, flags=re.IGNORECASE):
+        return uri
+    parsed = urlparse(uri)
+    query_params = parse_qs(parsed.query, keep_blank_values=True)
+    query_params.pop("dbname", None)
+    new_query = urlencode(query_params, doseq=True)
+    return urlunparse(parsed._replace(path=f"/{database_name}", query=new_query))
+
+
 def connectdb(db_config):
-    """
-    Establishes a connection to a PostgreSQL database using psycopg2.
-
-    Priority:
-    - If db_uri is provided, use it as the PostgreSQL connection string.
-    - If db_uri does not define connect_timeout, use connect_timeout=5.
-    - If db_uri does not define application_name, use application_name=pgAssistant.
-    - Otherwise, fall back to explicit connection fields.
-
-    Important:
-    - Do not rewrite the URI, because libpq options such as
-      options=-c%20search_path%3Dapp%2Cpublic are sensitive to URL encoding.
-    """
+    """Establishes a connection to a PostgreSQL database using psycopg2."""
+    db_config = resolve_db_config(normalize_db_config(db_config))
     try:
         db_uri = (db_config.get("db_uri") or "").strip()
 
         if db_uri:
             parsed_dsn = parse_dsn(db_uri)
-
             connect_kwargs = {}
-
             if "connect_timeout" not in parsed_dsn:
                 connect_kwargs["connect_timeout"] = 5
-
             if "application_name" not in parsed_dsn:
                 connect_kwargs["application_name"] = "pgAssistant"
-
             con = psycopg2.connect(db_uri, **connect_kwargs)
-
         else:
             con = psycopg2.connect(
                 database=db_config["db_name"],
@@ -109,11 +152,177 @@ def connectdb(db_config):
             )
 
         con.autocommit = True
-
     except psycopg2.Error as err:
         return None, format(err).rstrip()
 
     return con, "OK"
+
+
+def connectdb_to(db_config, database_name: str):
+    """Connect to a specific database on the same cluster."""
+    database_name = (database_name or "").strip()
+    if not database_name:
+        return connectdb(db_config)
+
+    cfg = dict(db_config)
+    cfg.pop("active_db", None)
+    uri = (cfg.get("db_uri") or "").strip()
+
+    if uri:
+        cfg["db_uri"] = _uri_with_database(uri, database_name)
+        cfg["db_name"] = database_name
+        return connectdb(cfg)
+
+    cfg["db_name"] = database_name
+    cfg.pop("db_uri", None)
+    return connectdb(cfg)
+
+
+def list_cluster_databases(db_config, con=None):
+    """List non-template databases with sizes (psql \\l+ equivalent)."""
+    close_connection = False
+    if con is None:
+        con, message = connectdb(db_config)
+        if not con:
+            return [], message
+        close_connection = True
+
+    cursor = None
+    try:
+        cursor = con.cursor()
+        cursor.execute(
+            """
+            SELECT
+                d.datname,
+                pg_catalog.pg_get_userbyid(d.datdba) AS owner,
+                pg_catalog.pg_encoding_to_char(d.encoding) AS encoding,
+                pg_catalog.pg_database_size(d.datname) AS size_bytes,
+                pg_catalog.pg_size_pretty(pg_catalog.pg_database_size(d.datname)) AS size_pretty,
+                (d.datname = current_database()) AS is_connected
+            FROM pg_catalog.pg_database d
+            WHERE NOT d.datistemplate
+            ORDER BY pg_catalog.pg_database_size(d.datname) DESC, d.datname ASC
+            """
+        )
+        rows = cursor.fetchall()
+        databases = [
+            {
+                "name": str(row[0]),
+                "owner": str(row[1] or ""),
+                "encoding": str(row[2] or ""),
+                "size_bytes": int(row[3] or 0),
+                "size_pretty": str(row[4] or "?"),
+                "is_connected": bool(row[5]),
+            }
+            for row in rows
+        ]
+        return databases, "OK"
+    except Exception as exc:
+        return [], str(exc)
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if close_connection and con is not None:
+            con.close()
+
+
+def _format_cluster_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    units = ["KB", "MB", "GB", "TB", "PB"]
+    value = float(size_bytes)
+    for unit in units:
+        value /= 1024.0
+        if value < 1024.0:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} PB"
+
+
+def get_db_info_cluster(db_config):
+    info = {"multi_db": True, "error": None}
+    con, message = connectdb(db_config)
+    if not con:
+        info["error"] = message
+        return info
+
+    try:
+        version, _ = db_query(con, "db_version")
+        info["version"] = version[0]["server_version"]
+
+        databases, db_message = list_cluster_databases(db_config, con=con)
+        if not databases and db_message != "OK":
+            info["error"] = db_message
+            return info
+
+        info["databases"] = databases
+        total_bytes = sum(db["size_bytes"] for db in databases)
+        info["size"] = _format_cluster_size(total_bytes)
+        info["size_bytes"] = total_bytes
+
+        cache_rows = json.loads(
+            db_fetch_json(
+                con,
+                """
+                SELECT
+                    ROUND(
+                        100.0 * SUM(blks_hit) / NULLIF(SUM(blks_hit) + SUM(blks_read), 0),
+                        2
+                    ) AS ratio
+                FROM pg_stat_database
+                WHERE datname NOT IN ('template0', 'template1')
+                """,
+            )
+        )
+        info["cache"] = float(cache_rows[0].get("ratio") or 0) if cache_rows else 0
+
+        try:
+            uptime, _ = db_query(con, "reporting_pguptime")
+            info["uptime"] = uptime[0]["uptime_pretty"]
+        except Exception:
+            info["uptime"] = "?"
+
+        try:
+            shared_buffers, _ = db_query(con, "shared_buffers_setting")
+            info["shared_buffers"] = shared_buffers[0]["current_setting"]
+        except Exception:
+            info["shared_buffers"] = "?"
+
+        info["profile"], _ = db_query(con, "reporting_db_profile")
+
+        connexions, _ = db_query(con, "database_count_connexions")
+        info["connexions"] = connexions[0]["nb"]
+
+        max_connexions, _ = db_query(con, "database_max_connexions")
+        info["max_connexions"] = max_connexions[0]["setting"]
+
+        database_top_clients, _ = db_query(con, "database_top_clients")
+        info["top_clients"] = database_top_clients
+
+        largest_tables = []
+        for db in databases[:20]:
+            db_con, db_status = connectdb_to(db_config, db["name"])
+            if not db_con:
+                continue
+            try:
+                rows, _ = db_query(db_con, "table_size_top_5")
+                for row in rows:
+                    item = dict(row)
+                    item["database"] = db["name"]
+                    largest_tables.append(item)
+            finally:
+                db_con.close()
+
+        largest_tables.sort(
+            key=lambda row: row.get("total_size_bytes") or row.get("size_bytes") or 0,
+            reverse=True,
+        )
+        info["table_size"] = largest_tables[:5]
+    finally:
+        con.close()
+
+    return info
+
+
 def db_exec(conn, sql):
     """
     Executes a SQL statement that does not return a result (e.g., INSERT, UPDATE).
@@ -199,41 +408,143 @@ def db_fetch_json(conn,sql):
     response = execute_and_fetch(cursor, sql)
     return json.dumps(response, default = defaultconverter)
 
+
+_PGSS_DB_FILTER_TAIL = (
+    "dbid = (SELECT oid FROM pg_database WHERE datname = {db_literal})"
+)
+
+
+def pg_stat_statements_has_dbid(con) -> bool:
+    """Return True when pg_stat_statements exposes cluster-wide dbid (PG 14+)."""
+    cursor = None
+    try:
+        cursor = con.cursor()
+        cursor.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_catalog.pg_class AS c
+                JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+                JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid
+                WHERE c.relname = 'pg_stat_statements'
+                  AND c.relkind IN ('v', 'm')
+                  AND NOT a.attisdropped
+                  AND a.attnum > 0
+                  AND a.attname = 'dbid'
+            )
+            """
+        )
+        row = cursor.fetchone()
+        return bool(row[0]) if row else False
+    except Exception:
+        return False
+    finally:
+        if cursor is not None:
+            cursor.close()
+
+
+def apply_pgss_database_filter(sql: str, database_name: str) -> str:
+    """Restrict pg_stat_statements rows to one database."""
+    if not sql or not database_name or re.search(r"\bdbid\b", sql, flags=re.IGNORECASE):
+        return sql
+    if "pg_stat_statements" not in sql.lower():
+        return sql
+
+    db_literal = _quote_sql_literal(database_name.strip())
+    clause = " AND " + _PGSS_DB_FILTER_TAIL.format(db_literal=db_literal) + " "
+    for pattern in (r"\bORDER\s+BY\b", r"\bLIMIT\b"):
+        match = re.search(pattern, sql, flags=re.IGNORECASE)
+        if match:
+            return sql[: match.start()] + clause + sql[match.start() :]
+
+    trimmed = sql.rstrip().rstrip(";")
+    if re.search(r"\bWHERE\b", trimmed, flags=re.IGNORECASE):
+        return trimmed + clause + ";"
+    return trimmed + f" WHERE {_PGSS_DB_FILTER_TAIL.format(db_literal=db_literal)};"
+
+
+def prepare_pgss_sql(sql: str, con, database_name: str) -> str:
+    """Apply a database filter to pg_stat_statements SQL when dbid is available."""
+    if not database_name:
+        return sql
+    if pg_stat_statements_has_dbid(con):
+        return apply_pgss_database_filter(sql, database_name)
+    return sql
+
+
+def inject_pgss_current_db_filter(sql: str) -> str:
+    """Backward-compatible alias using current_database()."""
+    db_literal = "current_database()"
+    if not sql or re.search(r"\bdbid\b", sql, flags=re.IGNORECASE):
+        return sql
+    if "pg_stat_statements" not in sql.lower():
+        return sql
+
+    clause = f" AND dbid = (SELECT oid FROM pg_database WHERE datname = {db_literal}) "
+    match = re.search(r"\bORDER\s+BY\b", sql, flags=re.IGNORECASE)
+    if match:
+        return sql[: match.start()] + clause + sql[match.start() :]
+
+    trimmed = sql.rstrip().rstrip(";")
+    if re.search(r"\bWHERE\b", trimmed, flags=re.IGNORECASE):
+        return trimmed + clause + ";"
+    return trimmed + f" WHERE dbid = (SELECT oid FROM pg_database WHERE datname = {db_literal});"
+
+
+def _db_query_pgss(cnx, query_id, db_config, db_name=None):
+    """Run a catalog query, scoping pg_stat_statements to the active database."""
+    get_queries()
+    database_name = get_resolved_database_name(db_config)
+
+    for query in PGA_QUERIES["sql"]:
+        if query["id"] != query_id:
+            continue
+        sql = query["sql"]
+        if db_name:
+            sql = sql.replace("$1", db_name)
+        sql = prepare_pgss_sql(sql, cnx, database_name)
+        if query["type"] == "select" or query["type"] == "param_query":
+            return json.loads(db_fetch_json(cnx, sql)), query
+        db_exec(cnx, sql)
+        return [], query
+    return [], None
+
+
 def get_top_queries(db_config):
     """
     Retrieves the top queries executed in the database.
-    """    
+    """
     rows = []
-    con, message = connectdb(db_config)
+    cfg = normalize_db_config(db_config)
+    con, message = connectdb(cfg)
     if con:
        try:
-            #print("DB VERSION =", db_config.get('version'))
-            if db_config.get('version')==18:
-               rows,description=db_query(con,'top_queries_18')
+            if cfg.get('version')==18:
+               rows, description = _db_query_pgss(con, 'top_queries_18', cfg)
             else:
-               rows,description=db_query(con,'top_queries')
+               rows, description = _db_query_pgss(con, 'top_queries', cfg)
        except:
-           rows=[] 
-       con.close()  
+           rows=[]
+       con.close()
     return rows
 
 
 def get_rank_queries(db_config):
     """
     Retrieves the ranked queries from the database.
-    """    
-    rows = [] 
-    con, message = connectdb(db_config)
+    """
+    rows = []
+    cfg = normalize_db_config(db_config)
+    con, message = connectdb(cfg)
     if con:
        try:
-            #print("DB VERSION =", db_config.get('version'))
-            if db_config.get('version')==18:
-               rows,description=db_query(con,'top_ranking_18')
+            if cfg.get('version')==18:
+               rows, description = _db_query_pgss(con, 'top_ranking_18', cfg)
             else:
-               rows,description=db_query(con,'top_ranking')
+               rows, description = _db_query_pgss(con, 'top_ranking', cfg)
        except:
-           rows=[] 
-       con.close()  
+           rows=[]
+       con.close()
     return rows
 
 def exec_cmd(db_config,query_id):
@@ -245,13 +556,19 @@ def exec_cmd(db_config,query_id):
        db_query(con,query_id)
        con.close()
 
-def generic_select(db_config,query_id):
-    rows = []
+def generic_select(db_config, query_id):
     con, message = connectdb(db_config)
-    if con:
-       rows,description=db_query(con,query_id)
-       con.close()
-       return rows, description
+    if not con:
+        return [], {"connection_error": message or "Unable to connect to database."}
+    try:
+        result = db_query(con, query_id)
+        if not result:
+            return [], None
+        return result
+    except Exception as exc:
+        return [], {"connection_error": str(exc)}
+    finally:
+        con.close()
 
 def generic_select_with_sql(db_config,sql):
     rows = []
@@ -328,6 +645,9 @@ def ensure_pg_stat_statements(con):
 
 
 def get_db_info(db_config,con=None):
+    if is_multi_db(db_config):
+        return get_db_info_cluster(db_config)
+
     info = {}
 
     if not con:
@@ -401,10 +721,13 @@ def get_query_by_id(query_id):
 def get_pgstat_query_by_id(db_config, query_id):
     query = get_query_by_id('pgstat_get_sqlquery_by_id')
     sql=query['sql'].replace ('$1', query_id)
-    con, _ = connectdb(db_config)
+    cfg = normalize_db_config(db_config)
+    db_name = get_resolved_database_name(cfg)
+    con, _ = connectdb(cfg)
     sql_text=''
     try:
         if con:
+            sql = prepare_pgss_sql(sql, con, db_name)
             sql_rows=json.loads(db_fetch_json(con,sql))
             if sql_rows:
                 sql_text=sql_rows[0].get('query') or ''
@@ -438,6 +761,8 @@ def db_query(cnx, query_id, db_name=None):
                 return json.loads(db_fetch_json(cnx,sql)),query
             else:
                 db_exec(cnx,sql)
+                return [], query
+    return [], None
 
 def get_query_by_id_reporing(query_id):
     get_queries()

--- a/apps/home/query_parameter_advisor.py
+++ b/apps/home/query_parameter_advisor.py
@@ -167,7 +167,7 @@ def _get_postgres_major_version(db_config: Dict[str, Any]) -> int:
         conn.close()
 
 
-def _fetch_pg_stat_statements_rows(conn) -> List[Dict[str, Any]]:
+def _fetch_pg_stat_statements_rows(conn, database_name: str = "") -> List[Dict[str, Any]]:
     """Read the workload snapshot used to aggregate runtime counters."""
     sql = """
         SELECT
@@ -195,6 +195,7 @@ def _fetch_pg_stat_statements_rows(conn) -> List[Dict[str, Any]]:
           AND lower(query) NOT LIKE '/* launched by pgassistant */%'
         ORDER BY total_exec_time DESC
     """
+    sql = database.prepare_pgss_sql(sql, conn, database_name)
     with conn.cursor() as cur:
         cur.execute(sql)
         columns = [desc[0] for desc in cur.description]
@@ -533,6 +534,7 @@ def analyze_query_parameter_workload(db_config: Dict[str, Any]) -> Dict[str, Any
     if conn is None:
         raise RuntimeError(status or "Unable to connect to database.")
 
+    db_name = database.get_resolved_database_name(db_config)
     plan_metrics = _empty_plan_metrics()
     planned_rows = []
     queries_planned = 0
@@ -540,7 +542,7 @@ def analyze_query_parameter_workload(db_config: Dict[str, Any]) -> Dict[str, Any
     queries_skipped_internal = 0
 
     try:
-        pgss_rows = _fetch_pg_stat_statements_rows(conn)
+        pgss_rows = _fetch_pg_stat_statements_rows(conn, db_name)
         statement_metrics = _aggregate_statement_metrics(pgss_rows)
 
         for row in pgss_rows:

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -16,6 +16,7 @@ from . import database
 from . import llm
 from . import pgstat_helper
 from .routes_helpers import (
+    apply_active_db_from_request,
     get_segment,
     handle_cache_table_get,
     handle_database_analyze_llm_get,
@@ -35,9 +36,13 @@ from .routes_helpers import (
     handle_reset_pg_stat,
     handle_reset_pg_statistics,
     handle_search_post,
+    handle_table_autovacuum_tune_get,
+    handle_table_autovacuum_tune_post,
     handle_table_rfc_get,
     handle_topqueries_get,
     handle_topstatistics_get,
+    is_db_connected,
+    multi_db_template_context,
 )
 
 config.init_or_load_env()
@@ -47,6 +52,22 @@ from . import route_api  # noqa: F401,E402
 from . import route_analyze  # noqa: F401,E402
 from . import route_llm_tables  # noqa: F401,E402
 from . import route_reports  # noqa: F401,E402
+
+
+@blueprint.before_request
+def _apply_multi_db_filter():
+    apply_active_db_from_request()
+
+
+@blueprint.context_processor
+def _inject_multi_db_context():
+    if not is_db_connected(session):
+        return {
+            "multi_db_filter": False,
+            "cluster_databases": [],
+            "active_db": "",
+        }
+    return multi_db_template_context(session)
 
 
 @blueprint.route('/index')
@@ -142,6 +163,10 @@ def route_template(template: str):
             return handle_database_analyze_llm_get(template, segment)
         elif segment == "database_analyze_llm.html" and request.method == 'POST':
             return handle_database_analyze_llm_post(template, segment)
+        elif segment == "table_autovacuum_tune.html" and request.method == 'GET':
+            return handle_table_autovacuum_tune_get(template, segment)
+        elif segment == "table_autovacuum_tune.html" and request.method == 'POST':
+            return handle_table_autovacuum_tune_post(template, segment)
         elif segment == "cache_table.html" and request.method == 'GET':
             return handle_cache_table_get(template, segment)
         elif segment == "llm.html" and request.method == 'GET':

--- a/apps/home/routes_helpers.py
+++ b/apps/home/routes_helpers.py
@@ -106,12 +106,25 @@ def require_db_connection():
     return None
 
 
+_CONNECTION_KEYS = (
+    "db_uri",
+    "db_host",
+    "db_port",
+    "db_name",
+    "db_user",
+    "db_password",
+)
+
+
 def _db_config_from_form(form, session_obj):
-    merged = dict(session_obj)
-    for key in ("db_uri", "db_host", "db_port", "db_name", "db_user", "db_password"):
+    """Build a fresh connection config from the form, without stale multi-db session state."""
+    merged = {
+        key: session_obj[key]
+        for key in _CONNECTION_KEYS
+        if session_obj.get(key)
+    }
+    for key in _CONNECTION_KEYS:
         if key not in form:
-            if key != "db_uri" and session_obj.get(key):
-                merged[key] = session_obj[key]
             continue
         val = form.get(key, "")
         if key == "db_uri":
@@ -120,9 +133,16 @@ def _db_config_from_form(form, session_obj):
                 merged["db_uri"] = uri
             else:
                 merged.pop("db_uri", None)
+        elif key == "db_password":
+            if str(val or "").strip():
+                merged["db_password"] = val
         elif str(val or "").strip():
-            merged[key] = val
+            merged[key] = val.strip() if isinstance(val, str) else val
+        else:
+            merged.pop(key, None)
     merged["multi_db"] = form.get("multi_db") == "on"
+    merged.pop("active_db", None)
+    merged.pop("cluster_databases", None)
     return merged
 
 

--- a/apps/home/routes_helpers.py
+++ b/apps/home/routes_helpers.py
@@ -15,34 +15,189 @@ from . import schema_helper
 from . import sqlcolumns
 from . import sqlhelper
 from . import stats
+from . import table_autovacuum_advisor
+
+
+def is_db_connected(session_obj) -> bool:
+    return bool(session_obj.get("db_connected"))
+
+
+def is_multi_db_session(session_obj) -> bool:
+    return is_db_connected(session_obj) and database.is_multi_db(session_obj)
+
+
+def get_active_db(session_obj) -> str:
+    if is_multi_db_session(session_obj):
+        return (session_obj.get("active_db") or session_obj.get("db_name") or "").strip()
+    return (session_obj.get("db_name") or "").strip()
+
+
+def get_cluster_database_names(session_obj) -> list[str]:
+    cached = session_obj.get("cluster_databases")
+    if cached:
+        return list(cached)
+
+    databases, _ = database.list_cluster_databases(session_obj)
+    names = [db["name"] for db in databases]
+    if names:
+        session_obj["cluster_databases"] = names
+        session_obj.modified = True
+    return names
+
+
+def set_active_db(session_obj, db_name: str) -> bool:
+    db_name = (db_name or "").strip()
+    if not db_name or not is_multi_db_session(session_obj):
+        return False
+
+    allowed = get_cluster_database_names(session_obj)
+    if db_name not in allowed:
+        session_obj.pop("cluster_databases", None)
+        allowed = get_cluster_database_names(session_obj)
+        if db_name not in allowed:
+            return False
+
+    session_obj["active_db"] = db_name
+    session_obj.modified = True
+    return True
+
+
+def sync_cluster_databases(session_obj):
+    if not database.is_multi_db(session_obj):
+        session_obj.pop("cluster_databases", None)
+        session_obj.pop("active_db", None)
+        return
+
+    names = get_cluster_database_names(session_obj)
+    active_db = (session_obj.get("db_name") or session_obj.get("active_db") or "").strip()
+    if active_db not in names and names:
+        active_db = names[0]
+    elif not active_db and names:
+        active_db = names[0]
+    session_obj["active_db"] = active_db
+    session_obj.modified = True
+
+
+def apply_active_db_from_request():
+    if not is_multi_db_session(session):
+        return
+    db_name = (request.args.get("db") or request.form.get("db") or "").strip()
+    if db_name:
+        set_active_db(session, db_name)
+
+
+def multi_db_template_context(session_obj):
+    if not is_multi_db_session(session_obj):
+        return {
+            "multi_db_filter": False,
+            "cluster_databases": [],
+            "active_db": get_active_db(session_obj),
+        }
+    return {
+        "multi_db_filter": True,
+        "cluster_databases": get_cluster_database_names(session_obj),
+        "active_db": get_active_db(session_obj),
+    }
+
+
+def require_db_connection():
+    if not is_db_connected(session):
+        return redirect("/database.html")
+    return None
+
+
+def _db_config_from_form(form, session_obj):
+    merged = dict(session_obj)
+    for key in ("db_uri", "db_host", "db_port", "db_name", "db_user", "db_password"):
+        if key not in form:
+            if key != "db_uri" and session_obj.get(key):
+                merged[key] = session_obj[key]
+            continue
+        val = form.get(key, "")
+        if key == "db_uri":
+            uri = str(val or "").strip()
+            if uri:
+                merged["db_uri"] = uri
+            else:
+                merged.pop("db_uri", None)
+        elif str(val or "").strip():
+            merged[key] = val
+    merged["multi_db"] = form.get("multi_db") == "on"
+    return merged
+
+
+def _connection_error_response(error_message: str, segment: str = "database.html"):
+    session["db_connected"] = False
+    session.modified = True
+    connection_form = {
+        key: session.get(key, "")
+        for key in ("db_uri", "db_host", "db_port", "db_name", "db_user", "db_password", "multi_db")
+    }
+    return render_template(
+        "home/database.html",
+        segment=segment,
+        dbinfo={"error": error_message},
+        connection_form=connection_form,
+    )
+
+
+def generic_select_session(query_id: str):
+    """Run generic_select with session and return a connection-error response when needed."""
+    rows, description = database.generic_select(session, query_id)
+    if isinstance(description, dict) and description.get("connection_error"):
+        return None, _connection_error_response(description["connection_error"])
+    return (rows, description), None
 
 
 def handle_database_post(segment: str):
     dbinfo = {}
+    merged = _db_config_from_form(request.form, session)
+    con, message = database.connectdb(merged)
+
+    if con is None:
+        return render_template(
+            f"home/{segment}",
+            segment=segment,
+            dbinfo={"error": message},
+            connection_form=merged,
+        )
+
     session.permanent = True
     for key, val in request.form.items():
+        if key == "multi_db":
+            continue
         session[key] = val
+    session["multi_db"] = request.form.get("multi_db") == "on"
+    session["db_connected"] = True
+    session.pop("cluster_databases", None)
+    session.pop("active_db", None)
+    sync_cluster_databases(session)
 
-    dbinfo = database.get_db_info(session)
-    
+    try:
+        dbinfo = database.get_db_info(session)
+        if dbinfo.get("error"):
+            session["db_connected"] = False
+            return render_template(
+                f"home/{segment}",
+                segment=segment,
+                dbinfo=dbinfo,
+                connection_form=merged,
+            )
+    finally:
+        con.close()
 
-    if "error" in dbinfo:
-        return render_template(f"home/{segment}", segment=segment, dbinfo=dbinfo)  
-
-    session['version']=database.get_pg_major_version(str(dbinfo['version']))
+    session["version"] = database.get_pg_major_version(str(dbinfo["version"]))
     session.modified = True
-
     return redirect("/dashboard.html")
 
 def handle_database_get(segment: str):
     return render_template(f"home/{segment}", segment=segment, dbinfo={})
 
 def handle_dashboard_get(segment: str):
-    if session.get("db_name"):
-        dbinfo = database.get_db_info(session)
-        return render_template("home/dashboard.html", segment=segment, dbinfo=dbinfo)
-    else:
+    if not is_db_connected(session):
         return redirect("/database.html")
+    dbinfo = database.get_db_info(session)
+    return render_template("home/dashboard.html", segment=segment, dbinfo=dbinfo)
 
 def handle_topqueries_get(template: str, segment: str, tablename: str = None):
 
@@ -123,18 +278,26 @@ def handle_topstatistics_get(template: str, segment: str):
         return redirect("/database.html")
 
 def handle_primarykey_get(template: str, segment: str):
-    if session.get("db_name"):
-            query_rows,description=database.generic_select(session,"issue_no_pk")
-            return render_template("home/primary_key.html", rows=query_rows, segment=segment, description=description )
-    else:
-        return redirect("/database.html")
+    redirect_response = require_db_connection()
+    if redirect_response:
+        return redirect_response
+
+    result, error_response = generic_select_session("issue_no_pk")
+    if error_response:
+        return error_response
+    query_rows, description = result
+    return render_template("home/primary_key.html", rows=query_rows, segment=segment, description=description)
 
 def handle_table_rfc_get(template: str, segment: str):
-    if session.get("db_name"):
-            query_rows,description=database.generic_select(session,"table_size")
-            return render_template("home/tables_cards.html", tables=query_rows, segment="tables_cards.html" )
-    else:
-        return redirect("/database.html")
+    redirect_response = require_db_connection()
+    if redirect_response:
+        return redirect_response
+
+    result, error_response = generic_select_session("table_size")
+    if error_response:
+        return error_response
+    query_rows, _description = result
+    return render_template("home/tables_cards.html", tables=query_rows, segment="tables_cards.html")
 
 def handle_indexes_get(template: str, segment: str):
     if session.get("db_name"):
@@ -197,24 +360,25 @@ def handle_database_analyze_llm_post(template: str, segment: str):
     )
 
 def handle_cache_table_get(template: str, segment: str):
-    if session.get("db_name"):
-            query_rows,description=database.generic_select(session,"hit_cache_by_table")
-            for row in query_rows:
-                # check and convert 'table_cache_hit_ratio'
-                try:
-                    row['table_cache_hit_ratio'] = float(row['table_cache_hit_ratio'])
-                except (ValueError, TypeError):
-                    row['table_cache_hit_ratio'] = 0  # Valeur invalide remplacée par None
+    redirect_response = require_db_connection()
+    if redirect_response:
+        return redirect_response
 
+    result, error_response = generic_select_session("hit_cache_by_table")
+    if error_response:
+        return error_response
+    query_rows, description = result
+    for row in query_rows:
+        try:
+            row['table_cache_hit_ratio'] = float(row['table_cache_hit_ratio'])
+        except (ValueError, TypeError):
+            row['table_cache_hit_ratio'] = 0
 
-                # check and convert 'index_cache_hit_ratio'
-                try:
-                    row['index_cache_hit_ratio'] = float(row['index_cache_hit_ratio'])
-                except (ValueError, TypeError):
-                    row['index_cache_hit_ratio'] = 0  # Invalid value replaced by 0          
-            return render_template("home/cache_table.html", rows=query_rows, segment=segment, description=description )
-    else:
-        return redirect("/database.html")
+        try:
+            row['index_cache_hit_ratio'] = float(row['index_cache_hit_ratio'])
+        except (ValueError, TypeError):
+            row['index_cache_hit_ratio'] = 0
+    return render_template("home/cache_table.html", rows=query_rows, segment=segment, description=description)
 
 def handle_reset_pg_stat():
     database.exec_cmd(session, "pg_stat_reset")
@@ -275,11 +439,56 @@ def handle_pgtune_post():
                            kubernetes_cmd=kubernetes_cmd
                            )
 
+def handle_table_autovacuum_tune_get(template: str, segment: str):
+    redirect_response = require_db_connection()
+    if redirect_response:
+        return redirect_response
+
+    stale_days = table_autovacuum_advisor.normalize_stale_days(
+        request.args.get("stale_days") or session.get("autovacuum_stale_days")
+    )
+    result = table_autovacuum_advisor.run_table_autovacuum_advisor(
+        session,
+        stale_days=stale_days,
+    )
+    return render_template(
+        f"home/{template}",
+        segment=segment,
+        advisor_result=result,
+        stale_days=stale_days,
+        criteria_help=table_autovacuum_advisor.build_criteria_help(stale_days),
+    )
+
+
+def handle_table_autovacuum_tune_post(template: str, segment: str):
+    redirect_response = require_db_connection()
+    if redirect_response:
+        return redirect_response
+
+    stale_days = table_autovacuum_advisor.normalize_stale_days(
+        request.form.get("stale_days") or session.get("autovacuum_stale_days")
+    )
+    session["autovacuum_stale_days"] = stale_days
+    session.modified = True
+
+    result = table_autovacuum_advisor.run_table_autovacuum_advisor(
+        session,
+        stale_days=stale_days,
+    )
+    return render_template(
+        f"home/{template}",
+        segment=segment,
+        advisor_result=result,
+        stale_days=stale_days,
+        criteria_help=table_autovacuum_advisor.build_criteria_help(stale_days),
+    )
+
+
 def get_segment(request):
     try:
         segment = request.path.split('/')[-1]
         if segment == '':
             segment = 'database'
         return segment
-    except:
+    except Exception:
         return None

--- a/apps/home/table_autovacuum_advisor.py
+++ b/apps/home/table_autovacuum_advisor.py
@@ -1,0 +1,1267 @@
+"""Per-table analyze and autovacuum tuning advisor based on advisor_enriched.yml rules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .database import connectdb, db_fetch_json
+from .global_advisor import load_recommendation_catalog
+
+MAINTENANCE_FLAGGED_RULE_ID = "table_autovacuum_maintenance_flagged"
+CLUSTER_LOAD_RULE_ID = "table_autovacuum_cluster_load"
+VACUUM_URGENCY_RULE_ID = "autovacuum_dead_tuple_vacuum_urgency"
+DEFAULT_STALE_DAYS = 7
+DEFAULT_MIN_TABLE_BYTES = 1024 * 1024
+DEAD_TUPLE_MIN_ABSOLUTE = 10_000
+DEAD_TUPLE_MIN_RATIO = 0.05
+DEAD_TUPLE_HIGH_ABSOLUTE = 100_000
+LARGE_TABLE_BYTES = 1024**3
+LARGE_TABLE_DEAD_RATIO = 0.20
+
+
+def normalize_stale_days(value: str | int | None) -> int:
+    try:
+        days = int(value or DEFAULT_STALE_DAYS)
+    except (TypeError, ValueError):
+        days = DEFAULT_STALE_DAYS
+    return max(1, min(365, days))
+
+
+def _find_rule(catalog: list[dict[str, Any]], rule_id: str) -> dict[str, Any] | None:
+    for item in catalog:
+        if item.get("id") == rule_id:
+            return item
+    return None
+
+
+def render_rule_sql(sql_template: str, **params: Any) -> str:
+    rendered = sql_template
+    for key, value in params.items():
+        rendered = rendered.replace(f"{{{{{key}}}}}", str(value))
+    return rendered
+
+
+def get_rule_sql(catalog: list[dict[str, Any]], rule_id: str, **params: Any) -> str:
+    rule = _find_rule(catalog, rule_id)
+    if not rule or not rule.get("sql"):
+        raise ValueError(f"Advisor rule not found or missing SQL: {rule_id}")
+    return render_rule_sql(rule["sql"], **params)
+
+
+ISSUE_SORT_ORDER = {
+    "never_vacuumed": 0,
+    "never_analyzed": 1,
+    "stale_vacuum": 2,
+    "stale_analyze": 3,
+}
+
+
+def _normalize_issue_types(raw_value: Any) -> list[str]:
+    if raw_value is None:
+        return []
+    if isinstance(raw_value, list):
+        return [str(item) for item in raw_value if item]
+    if isinstance(raw_value, str):
+        raw_value = raw_value.strip()
+        if raw_value.startswith("{") and raw_value.endswith("}"):
+            inner = raw_value[1:-1]
+            if not inner:
+                return []
+            return [part.strip().strip('"') for part in inner.split(",") if part.strip()]
+    return []
+
+
+def _primary_issue_type(issue_types: list[str]) -> str:
+    if not issue_types:
+        return "stale_analyze"
+    return min(issue_types, key=lambda item: ISSUE_SORT_ORDER.get(item, 99))
+
+
+def _quote_ident(value: str) -> str:
+    value = (value or "").replace('"', '""')
+    return f'"{value}"'
+
+
+def build_analyze_sql(schema_name: str, table_name: str) -> str:
+    return f"ANALYZE {_quote_ident(schema_name)}.{_quote_ident(table_name)};"
+
+
+def build_vacuum_sql(schema_name: str, table_name: str) -> str:
+    return f"VACUUM {_quote_ident(schema_name)}.{_quote_ident(table_name)};"
+
+
+def compute_autovacuum_tuning(
+    *,
+    n_live_tup: int = 0,
+    n_dead_tup: int = 0,
+    table_size_bytes: int = 0,
+    modified_since_analyze_ratio: float = 0.0,
+    vacuum_urgency: float = 0.0,
+    never_analyzed: bool = False,
+) -> dict[str, Any]:
+    """Compute per-table autovacuum thresholds and the rules applied."""
+    analyze_scale_factor = 0.05
+    analyze_threshold = 1000
+    vacuum_scale_factor = 0.05
+    vacuum_threshold = 1000
+    adjustments: list[str] = []
+
+    is_huge = n_live_tup >= 10_000_000 or table_size_bytes >= 10 * 1024**3
+    is_large = n_live_tup >= 1_000_000 or table_size_bytes >= 1024**3
+    dead_ratio = n_dead_tup / max(n_live_tup, 1)
+
+    if is_huge:
+        analyze_scale_factor = 0.01
+        analyze_threshold = 5000
+        vacuum_scale_factor = 0.02
+        vacuum_threshold = 5000
+        adjustments.append("Very large table (≥ 10M rows or ≥ 10 GiB): base thresholds reduced.")
+    elif is_large:
+        analyze_scale_factor = 0.02
+        analyze_threshold = 2000
+        vacuum_scale_factor = 0.03
+        vacuum_threshold = 2000
+        adjustments.append("Large table (≥ 1M rows or ≥ 1 GiB): base thresholds reduced.")
+    else:
+        adjustments.append("Default starting thresholds (scale factor 0.05, threshold 1000).")
+
+    if never_analyzed or modified_since_analyze_ratio >= 0.30:
+        analyze_scale_factor = min(analyze_scale_factor, 0.02)
+        analyze_threshold = max(analyze_threshold, 500)
+        if never_analyzed:
+            adjustments.append("Never analyzed: analyze thresholds tightened.")
+        else:
+            adjustments.append(
+                f"≥ 30% rows modified since analyze ({modified_since_analyze_ratio * 100:.1f}%): "
+                "analyze thresholds tightened."
+            )
+
+    if vacuum_urgency >= 2:
+        vacuum_scale_factor = 0.01
+        vacuum_threshold = max(vacuum_threshold, 2000)
+        adjustments.append(f"Vacuum urgency critical ({vacuum_urgency:.2f}): vacuum thresholds aggressively reduced.")
+    elif vacuum_urgency >= 1:
+        vacuum_scale_factor = min(vacuum_scale_factor, 0.02)
+        adjustments.append(f"Elevated vacuum urgency ({vacuum_urgency:.2f}): vacuum scale factor reduced.")
+
+    if is_huge and (dead_ratio >= 0.02 or n_dead_tup >= 500_000):
+        vacuum_scale_factor = min(vacuum_scale_factor, 0.005)
+        vacuum_threshold = min(vacuum_threshold, 500)
+        analyze_scale_factor = min(analyze_scale_factor, 0.005)
+        analyze_threshold = min(analyze_threshold, 500)
+        adjustments.append(
+            f"High dead pressure on very large table ({n_dead_tup:,} dead, {dead_ratio * 100:.1f}% of live): "
+            "vacuum/analyze thresholds lowered."
+        )
+    elif is_large and (dead_ratio >= 0.05 or n_dead_tup >= 100_000):
+        vacuum_scale_factor = min(vacuum_scale_factor, 0.01)
+        vacuum_threshold = min(vacuum_threshold, 1000)
+        analyze_scale_factor = min(analyze_scale_factor, 0.01)
+        analyze_threshold = min(analyze_threshold, 1000)
+        adjustments.append(
+            f"High dead pressure on large table ({n_dead_tup:,} dead, {dead_ratio * 100:.1f}% of live): "
+            "vacuum/analyze thresholds lowered."
+        )
+
+    if n_dead_tup >= 1_000_000:
+        vacuum_scale_factor = min(vacuum_scale_factor, 0.005)
+        vacuum_threshold = min(vacuum_threshold, 200)
+        adjustments.append(f"≥ 1M dead tuples ({n_dead_tup:,}): vacuum thresholds minimized.")
+
+    vacuum_trigger_at = int(round(vacuum_threshold + vacuum_scale_factor * n_live_tup))
+    analyze_trigger_at = int(round(analyze_threshold + analyze_scale_factor * n_live_tup))
+
+    return {
+        "analyze_scale_factor": analyze_scale_factor,
+        "analyze_threshold": analyze_threshold,
+        "vacuum_scale_factor": vacuum_scale_factor,
+        "vacuum_threshold": vacuum_threshold,
+        "adjustments": adjustments,
+        "size_class": "huge" if is_huge else "large" if is_large else "normal",
+        "dead_ratio_pct": round(dead_ratio * 100, 2),
+        "vacuum_trigger_at": vacuum_trigger_at,
+        "analyze_trigger_at": analyze_trigger_at,
+        "vacuum_formula": (
+            f"dead_tuples ≥ {vacuum_threshold} + {vacuum_scale_factor:g} × {n_live_tup:,} "
+            f"= {vacuum_trigger_at:,}"
+        ),
+        "analyze_formula": (
+            f"modified_rows ≥ {analyze_threshold} + {analyze_scale_factor:g} × {n_live_tup:,} "
+            f"= {analyze_trigger_at:,}"
+        ),
+    }
+
+
+def build_autovacuum_tuning_sql(
+    schema_name: str,
+    table_name: str,
+    *,
+    n_live_tup: int = 0,
+    n_dead_tup: int = 0,
+    table_size_bytes: int = 0,
+    modified_since_analyze_ratio: float = 0.0,
+    vacuum_urgency: float = 0.0,
+    never_analyzed: bool = False,
+) -> str:
+    tuning = compute_autovacuum_tuning(
+        n_live_tup=n_live_tup,
+        n_dead_tup=n_dead_tup,
+        table_size_bytes=table_size_bytes,
+        modified_since_analyze_ratio=modified_since_analyze_ratio,
+        vacuum_urgency=vacuum_urgency,
+        never_analyzed=never_analyzed,
+    )
+    return (
+        f"ALTER TABLE {_quote_ident(schema_name)}.{_quote_ident(table_name)} SET (\n"
+        f"  autovacuum_analyze_scale_factor = {tuning['analyze_scale_factor']},\n"
+        f"  autovacuum_analyze_threshold = {tuning['analyze_threshold']},\n"
+        f"  autovacuum_vacuum_scale_factor = {tuning['vacuum_scale_factor']},\n"
+        f"  autovacuum_vacuum_threshold = {tuning['vacuum_threshold']}\n"
+        f");"
+    )
+
+
+def build_table_calculation_help(
+    *,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    issue_types: list[str] | None = None,
+    priority: str = "MEDIUM",
+    recommendation_note: str = "",
+    never_analyzed: bool = False,
+    stale_analyze: bool = False,
+    never_vacuumed: bool = False,
+    stale_vacuum: bool = False,
+    needs_vacuum_pressure: bool = False,
+    stats_age_days: Any = None,
+    vacuum_age_days: Any = None,
+    n_live_tup: int = 0,
+    n_dead_tup: int = 0,
+    n_mod_since_analyze: int = 0,
+    modified_since_analyze_pct: Any = None,
+    dead_tuple_pct: Any = None,
+    table_size_pretty: str = "",
+    vacuum_urgency: float = 0.0,
+    alter_available: bool = False,
+    alter_skip_reason: str = "",
+    tuning: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Structured per-table explanation for the UI help modal."""
+    stale_days = normalize_stale_days(stale_days)
+    issue_types = issue_types or []
+    flagging_points: list[str] = []
+
+    if never_analyzed:
+        flagging_points.append("No manual or auto analyze recorded.")
+    elif stale_analyze:
+        flagging_points.append(
+            f"Last analyze/autoanalyze is older than {stale_days} day(s)"
+            + (f" ({stats_age_days} d)." if stats_age_days is not None else ".")
+        )
+    else:
+        flagging_points.append(
+            f"Statistics are fresh (within {stale_days} day(s)"
+            + (f", age {stats_age_days} d)." if stats_age_days is not None else ").")
+        )
+
+    if never_vacuumed or stale_vacuum:
+        if needs_vacuum_pressure:
+            flagging_points.append(
+                f"Vacuum pressure detected: {n_dead_tup:,} dead tuples"
+                + (f", {dead_tuple_pct}% dead/live." if dead_tuple_pct is not None else ".")
+            )
+            if never_vacuumed:
+                flagging_points.append("Vacuum/autovacuum has never run on this table.")
+            elif stale_vacuum:
+                flagging_points.append(
+                    f"Last vacuum/autovacuum is older than {stale_days} day(s)"
+                    + (f" ({vacuum_age_days} d)." if vacuum_age_days is not None else ".")
+                )
+        else:
+            flagging_points.append("Vacuum age alone is not enough without dead tuple pressure.")
+    else:
+        flagging_points.append("No vacuum issue under current dead-tuple criteria.")
+
+    metrics = [
+        f"Priority: {priority}",
+        f"Size: {table_size_pretty or '—'}",
+        f"Live rows: {n_live_tup:,}",
+        f"Dead tuples: {n_dead_tup:,}",
+    ]
+    if modified_since_analyze_pct is not None:
+        metrics.append(f"Modified since analyze: {modified_since_analyze_pct}% ({n_mod_since_analyze:,} rows)")
+    if vacuum_urgency:
+        metrics.append(f"Vacuum urgency (YAML rule): {vacuum_urgency}")
+
+    alter_section: dict[str, Any] = {
+        "available": alter_available,
+        "skip_reason": alter_skip_reason,
+        "preview_only": not alter_available and bool(tuning),
+    }
+    if tuning:
+        alter_section.update(
+            {
+                "parameters": {
+                    "autovacuum_analyze_scale_factor": tuning["analyze_scale_factor"],
+                    "autovacuum_analyze_threshold": tuning["analyze_threshold"],
+                    "autovacuum_vacuum_scale_factor": tuning["vacuum_scale_factor"],
+                    "autovacuum_vacuum_threshold": tuning["vacuum_threshold"],
+                },
+                "adjustments": tuning.get("adjustments") or [],
+                "vacuum_formula": tuning.get("vacuum_formula"),
+                "analyze_formula": tuning.get("analyze_formula"),
+                "vacuum_trigger_at": tuning.get("vacuum_trigger_at"),
+                "analyze_trigger_at": tuning.get("analyze_trigger_at"),
+            }
+        )
+
+    return {
+        "stale_days": stale_days,
+        "issue_types": issue_types,
+        "recommendation_note": recommendation_note,
+        "flagging": flagging_points,
+        "metrics": metrics,
+        "alter": alter_section,
+    }
+
+
+def build_tuning_rationale(
+    *,
+    n_live_tup: int = 0,
+    n_dead_tup: int = 0,
+    table_size_bytes: int = 0,
+    modified_since_analyze_ratio: float = 0.0,
+    vacuum_urgency: float = 0.0,
+    never_analyzed: bool = False,
+) -> str:
+    notes: list[str] = []
+    dead_ratio = n_dead_tup / max(n_live_tup, 1)
+    is_huge = n_live_tup >= 10_000_000 or table_size_bytes >= 10 * 1024**3
+    is_large = n_live_tup >= 1_000_000 or table_size_bytes >= 1024**3
+
+    if never_analyzed:
+        notes.append("Statistics were never collected; analyze thresholds are tightened.")
+    elif modified_since_analyze_ratio >= 0.30:
+        notes.append("Many rows changed since the last analyze; analyze thresholds are tightened.")
+
+    if is_huge:
+        notes.append("Very large table: default autovacuum scale factors would trigger too late.")
+    elif is_large:
+        notes.append("Large table: per-table thresholds are reduced versus PostgreSQL defaults.")
+
+    if n_dead_tup >= 1_000_000 or (is_huge and dead_ratio >= 0.02) or (is_large and dead_ratio >= 0.05):
+        notes.append(
+            f"High dead tuple pressure ({n_dead_tup:,} dead, {dead_ratio * 100:.1f}% of live rows): "
+            "vacuum/analyze scale factors are lowered so maintenance can still run."
+        )
+
+    if vacuum_urgency >= 2:
+        notes.append("Vacuum urgency is critical; vacuum thresholds are aggressively reduced.")
+    elif vacuum_urgency >= 1:
+        notes.append("Elevated vacuum urgency; vacuum scale factor is reduced.")
+
+    if not notes:
+        notes.append("Starting-point per-table autovacuum settings based on table size and activity.")
+    return " ".join(notes)
+
+
+def build_criteria_help(stale_days: int = DEFAULT_STALE_DAYS) -> dict[str, Any]:
+    """Structured help text describing flagging and tuning algorithms."""
+    stale_days = normalize_stale_days(stale_days)
+    min_table_mb = DEFAULT_MIN_TABLE_BYTES // (1024 * 1024)
+    dead_ratio_pct = int(DEAD_TUPLE_MIN_RATIO * 100)
+    large_dead_ratio_pct = int(LARGE_TABLE_DEAD_RATIO * 100)
+
+    return {
+        "stale_days": stale_days,
+        "sections": [
+            {
+                "id": "selection",
+                "title": "Which tables appear in the report",
+                "points": [
+                    f"Only user tables ≥ {min_table_mb} MiB are considered.",
+                    "A table is listed when it needs ANALYZE (missing or stale statistics) "
+                    f"and/or VACUUM (dead tuple pressure with an overdue vacuum).",
+                    "An old vacuum timestamp alone is not enough: low dead tuple pressure "
+                    "does not flag a table for vacuum.",
+                ],
+            },
+            {
+                "id": "analyze",
+                "title": "ANALYZE criteria",
+                "points": [
+                    f"Reference date: GREATEST(last_analyze, last_autoanalyze) — manual ANALYZE "
+                    "counts the same as autovacuum.",
+                    f"never_analyzed: no manual or auto analyze recorded.",
+                    f"stale_analyze: last analyze/autoanalyze is older than {stale_days} day(s).",
+                    "If statistics were refreshed within the threshold, the table is not flagged "
+                    "for analyze even when autovacuum never ran.",
+                ],
+            },
+            {
+                "id": "vacuum",
+                "title": "VACUUM criteria (dead tuple pressure required)",
+                "points": [
+                    f"Reference date: GREATEST(last_vacuum, last_autovacuum).",
+                    "needs_vacuum_pressure is true when any of:",
+                    f"  • n_dead_tup ≥ {DEAD_TUPLE_MIN_ABSOLUTE:,} AND dead/live ratio ≥ {dead_ratio_pct}%",
+                    f"  • n_dead_tup ≥ {DEAD_TUPLE_HIGH_ABSOLUTE:,}",
+                    f"  • table ≥ 1 GiB AND dead/live ratio ≥ {large_dead_ratio_pct}%",
+                    "never_vacuumed: no vacuum/autovacuum recorded AND needs_vacuum_pressure.",
+                    f"stale_vacuum: last vacuum/autovacuum older than {stale_days} day(s) "
+                    "AND needs_vacuum_pressure.",
+                    "dead/live ratio = n_dead_tup / (n_live_tup + n_dead_tup).",
+                ],
+            },
+            {
+                "id": "priority",
+                "title": "Priority levels (pga_recommendation_level)",
+                "points": [
+                    "HIGH: never analyzed; or stale analyze with > 20% rows modified since analyze; "
+                    "or vacuum issue with ≥ 10k dead tuples and ≥ 5% dead/live ratio; "
+                    "or never vacuumed with ≥ 100k dead tuples.",
+                    "MEDIUM: other analyze or vacuum issues.",
+                ],
+            },
+            {
+                "id": "alter",
+                "title": "Per-table ALTER TABLE autovacuum tuning",
+                "points": [
+                    "Available only after at least one ANALYZE (manual or auto).",
+                    "Base thresholds: analyze_scale_factor=0.05, analyze_threshold=1000, "
+                    "vacuum_scale_factor=0.05, vacuum_threshold=1000.",
+                    "Large table (≥ 1M rows or ≥ 1 GiB): scale factors → 0.02–0.03, thresholds → 2000.",
+                    "Very large (≥ 10M rows or ≥ 10 GiB): scale factors → 0.01–0.02, thresholds → 5000.",
+                    "Stale stats (≥ 30% modified since analyze): analyze thresholds tightened.",
+                    "High dead pressure or vacuum_urgency ≥ 1: vacuum scale factor reduced.",
+                    "vacuum_urgency ≥ 2: vacuum_scale_factor=0.01, threshold ≥ 2000.",
+                    "≥ 1M dead tuples: vacuum_scale_factor ≤ 0.005, threshold ≤ 200.",
+                    "PostgreSQL triggers autovacuum when: "
+                    "dead_tuples ≥ vacuum_threshold + vacuum_scale_factor × n_live_tup "
+                    "(same pattern for analyze).",
+                ],
+            },
+            {
+                "id": "global",
+                "title": "Global ALTER SYSTEM recommendations",
+                "points": [
+                    "Cluster load score from: total dead tuples, high-dead-pressure tables, "
+                    "critical vacuum_urgency count, flagged table count, saturated autovacuum workers.",
+                    "Score ≥ 7 → critical, ≥ 4 → high, ≥ 2 → medium, else low.",
+                    "Targets adjust autovacuum_max_workers, naptime, scale factors, cost delay/limit, "
+                    "and log_autovacuum_min_duration by load level.",
+                    "autovacuum_max_workers requires a PostgreSQL restart; other parameters reload "
+                    "with SELECT pg_reload_conf();.",
+                ],
+            },
+        ],
+    }
+
+
+def build_restore_script(analyze_sql: str, vacuum_sql: str, autovacuum_sql: str = "") -> str:
+    lines = [
+        "-- 1) Reclaim dead tuples (manual vacuum if autovacuum is lagging)",
+        vacuum_sql,
+        "",
+        "-- 2) Refresh planner statistics",
+        analyze_sql,
+    ]
+    if autovacuum_sql:
+        lines.extend(
+            [
+                "",
+                "-- 3) Tune per-table autovacuum thresholds",
+                autovacuum_sql,
+            ]
+        )
+    return "\n".join(lines)
+
+
+def get_execution_risks(
+    action: str,
+    *,
+    parameter: str = "",
+    context: str = "",
+    table_name: str = "",
+) -> list[str]:
+    risks: list[str] = []
+
+    if action == "analyze":
+        risks.extend(
+            [
+                "Acquires a SHARE UPDATE EXCLUSIVE lock: concurrent DDL on this table may wait.",
+                "Can increase I/O and CPU while statistics are collected; large tables may run for a long time.",
+                "Does not reclaim dead tuples by itself.",
+            ]
+        )
+    elif action == "vacuum":
+        risks.extend(
+            [
+                "Increases I/O and may compete with application traffic during cleanup.",
+                "Uses a SHARE UPDATE EXCLUSIVE lock (reads/writes continue, but some DDL can be blocked).",
+                "On very large tables, runtime can be significant — prefer a low-traffic window.",
+                "This is a plain VACUUM, not VACUUM FULL: it does not return disk space to the OS.",
+            ]
+        )
+    elif action == "alter_table":
+        risks.extend(
+            [
+                "Changes per-table autovacuum thresholds until RESET or overridden again.",
+                "More aggressive settings can increase background autovacuum I/O on this table.",
+                "Does not run ANALYZE or VACUUM immediately; it only affects future autovacuum behavior.",
+            ]
+        )
+    elif action == "alter_system":
+        risks.extend(
+            [
+                "Changes cluster-wide PostgreSQL configuration via ALTER SYSTEM.",
+                "Requires sufficient privileges (typically superuser or pg_write_all_settings).",
+                "Incorrect values can increase I/O pressure or trigger excessive autovacuum activity.",
+            ]
+        )
+        if context == "postmaster" or parameter == "autovacuum_max_workers":
+            risks.append(
+                f"{parameter or 'This parameter'} requires a PostgreSQL restart before it takes effect."
+            )
+        else:
+            risks.append("Most parameters require SELECT pg_reload_conf(); after applying.")
+    elif action == "reload_conf":
+        risks.extend(
+            [
+                "Reloads PostgreSQL configuration for parameters that support SIGHUP reload.",
+                "Postmaster-level parameters (for example autovacuum_max_workers) still need a restart.",
+            ]
+        )
+    elif action == "alter_system_batch":
+        risks.extend(
+            [
+                "Applies several cluster-wide configuration changes in sequence.",
+                "Requires sufficient privileges and a maintenance review before production use.",
+                "Some parameters only take effect after pg_reload_conf() or a full restart.",
+            ]
+        )
+
+    if table_name:
+        risks.append(f"Target table: {table_name}.")
+
+    return risks
+
+
+def get_batch_execution_risks(action: str, table_count: int = 0) -> list[str]:
+    table_count = max(0, int(table_count or 0))
+    risks: list[str] = []
+
+    if action in {"vacuum", "all"}:
+        risks.extend(get_execution_risks("vacuum"))
+    if action in {"analyze", "all"}:
+        risks.extend(get_execution_risks("analyze"))
+    if action in {"alter", "all"}:
+        risks.extend(get_execution_risks("alter_table"))
+
+    labels = {
+        "vacuum": "VACUUM",
+        "analyze": "ANALYZE",
+        "alter": "ALTER TABLE",
+        "all": "VACUUM, ANALYZE and ALTER TABLE",
+    }
+    risks.append(
+        f"Batch run: executes {labels.get(action, action)} sequentially on "
+        f"{table_count} flagged table(s)."
+    )
+    risks.append("Total runtime and I/O can be significant; prefer a maintenance window.")
+    if action == "all":
+        risks.append("Order is VACUUM → ANALYZE → ALTER TABLE for each flagged table group.")
+    if action == "alter":
+        risks.append("ALTER TABLE changes persist until RESET or manual override.")
+
+    deduped: list[str] = []
+    for risk in risks:
+        if risk not in deduped:
+            deduped.append(risk)
+    return deduped
+
+
+def build_batch_actions(tables: list[dict[str, Any]]) -> dict[str, Any]:
+    count = len(tables)
+    alter_eligible = sum(1 for table in tables if table.get("alter_available"))
+    return {
+        "table_count": count,
+        "alter_eligible_count": alter_eligible,
+        "vacuum": {"risks": get_batch_execution_risks("vacuum", count)},
+        "analyze": {"risks": get_batch_execution_risks("analyze", count)},
+        "alter": {"risks": get_batch_execution_risks("alter", alter_eligible)},
+        "all": {"risks": get_batch_execution_risks("all", count)},
+    }
+
+
+def _table_key(schema_name: str, table_name: str) -> str:
+    return f"{schema_name}.{table_name}"
+
+
+GLOBAL_AUTOVACUUM_SETTINGS = (
+    "autovacuum",
+    "autovacuum_max_workers",
+    "autovacuum_naptime",
+    "autovacuum_vacuum_scale_factor",
+    "autovacuum_vacuum_threshold",
+    "autovacuum_analyze_scale_factor",
+    "autovacuum_analyze_threshold",
+    "autovacuum_vacuum_cost_delay",
+    "autovacuum_vacuum_cost_limit",
+    "log_autovacuum_min_duration",
+    "max_worker_processes",
+)
+
+
+def _parse_setting_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_setting_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _format_alter_system_value(parameter: str, value: Any) -> str:
+    if parameter == "autovacuum_naptime":
+        seconds = _parse_setting_int(value, 60)
+        return f"'{seconds}s'"
+    if parameter == "log_autovacuum_min_duration":
+        text = str(value)
+        if text.isdigit():
+            return f"'{text}ms'" if int(text) >= 0 else "'-1'"
+        return f"'{text.replace(chr(39), chr(39) + chr(39))}'"
+    if parameter == "autovacuum":
+        return "on" if str(value).lower() in {"1", "true", "on"} else str(value)
+    if isinstance(value, float):
+        text = f"{value:g}"
+        return text if "." in text else f"{text}.0" if parameter.endswith("_factor") else text
+    return str(value)
+
+
+def _build_alter_system_sql(parameter: str, value: Any) -> str:
+    literal = _format_alter_system_value(parameter, value)
+    if literal.startswith("'") or literal in {"on", "off"}:
+        if literal in {"on", "off"}:
+            return f"ALTER SYSTEM SET {parameter} = {literal};"
+        return f"ALTER SYSTEM SET {parameter} = {literal};"
+    return f"ALTER SYSTEM SET {parameter} = {literal};"
+
+
+def assess_cluster_load(
+    *,
+    total_dead_tuples: int = 0,
+    high_dead_pressure_tables: int = 0,
+    never_vacuumed_tables: int = 0,
+    flagged_table_count: int = 0,
+    critical_vacuum_count: int = 0,
+    elevated_vacuum_count: int = 0,
+    active_autovacuum_workers: int = 0,
+    current_max_workers: int = 3,
+    user_table_count: int = 0,
+) -> str:
+    score = 0
+
+    if total_dead_tuples >= 10_000_000:
+        score += 3
+    elif total_dead_tuples >= 1_000_000:
+        score += 2
+    elif total_dead_tuples >= 100_000:
+        score += 1
+
+    if high_dead_pressure_tables >= 20:
+        score += 3
+    elif high_dead_pressure_tables >= 10:
+        score += 2
+    elif high_dead_pressure_tables >= 3:
+        score += 1
+
+    if critical_vacuum_count >= 5:
+        score += 2
+    elif critical_vacuum_count >= 1:
+        score += 1
+
+    if elevated_vacuum_count >= 10:
+        score += 1
+
+    if flagged_table_count >= 50:
+        score += 2
+    elif flagged_table_count >= 15:
+        score += 1
+
+    if never_vacuumed_tables >= 10:
+        score += 1
+
+    if (
+        current_max_workers > 0
+        and active_autovacuum_workers >= current_max_workers
+        and (high_dead_pressure_tables >= 3 or total_dead_tuples >= 500_000)
+    ):
+        score += 2
+
+    if user_table_count >= 500 and total_dead_tuples >= 250_000:
+        score += 1
+
+    if score >= 7:
+        return "critical"
+    if score >= 4:
+        return "high"
+    if score >= 2:
+        return "medium"
+    return "low"
+
+
+def _recommended_max_workers(
+    load_level: str,
+    user_table_count: int,
+    max_worker_processes: int,
+    current_max_workers: int,
+) -> int:
+    if load_level == "low":
+        return current_max_workers
+    if load_level == "medium":
+        target = max(3, min(6, (user_table_count // 250) + 3))
+    elif load_level == "high":
+        target = max(4, min(8, (user_table_count // 120) + 4))
+    else:
+        target = max(5, min(10, (user_table_count // 80) + 5))
+
+    ceiling = max(3, max_worker_processes - 2)
+    return max(current_max_workers, min(target, ceiling))
+
+
+def build_global_autovacuum_targets(
+    load_level: str,
+    *,
+    user_table_count: int = 0,
+    max_worker_processes: int = 8,
+    current_max_workers: int = 3,
+) -> dict[str, Any]:
+    targets: dict[str, Any] = {}
+
+    if load_level == "low":
+        targets.update(
+            {
+                "autovacuum_vacuum_scale_factor": 0.1,
+                "autovacuum_analyze_scale_factor": 0.05,
+                "autovacuum_vacuum_threshold": 50,
+                "autovacuum_analyze_threshold": 50,
+                "autovacuum_naptime": 60,
+                "autovacuum_vacuum_cost_delay": 2,
+                "autovacuum_vacuum_cost_limit": -1,
+                "log_autovacuum_min_duration": "10min",
+            }
+        )
+    elif load_level == "medium":
+        targets.update(
+            {
+                "autovacuum_vacuum_scale_factor": 0.1,
+                "autovacuum_analyze_scale_factor": 0.05,
+                "autovacuum_vacuum_threshold": 50,
+                "autovacuum_analyze_threshold": 50,
+                "autovacuum_naptime": 30,
+                "autovacuum_vacuum_cost_delay": 2,
+                "autovacuum_vacuum_cost_limit": 1000,
+                "log_autovacuum_min_duration": "5min",
+            }
+        )
+    elif load_level == "high":
+        targets.update(
+            {
+                "autovacuum_vacuum_scale_factor": 0.05,
+                "autovacuum_analyze_scale_factor": 0.02,
+                "autovacuum_vacuum_threshold": 50,
+                "autovacuum_analyze_threshold": 50,
+                "autovacuum_naptime": 15,
+                "autovacuum_vacuum_cost_delay": 1,
+                "autovacuum_vacuum_cost_limit": 2000,
+                "log_autovacuum_min_duration": "1min",
+            }
+        )
+    else:
+        targets.update(
+            {
+                "autovacuum_vacuum_scale_factor": 0.02,
+                "autovacuum_analyze_scale_factor": 0.01,
+                "autovacuum_vacuum_threshold": 25,
+                "autovacuum_analyze_threshold": 25,
+                "autovacuum_naptime": 10,
+                "autovacuum_vacuum_cost_delay": 0,
+                "autovacuum_vacuum_cost_limit": 3000,
+                "log_autovacuum_min_duration": "0",
+            }
+        )
+
+    targets["autovacuum_max_workers"] = _recommended_max_workers(
+        load_level,
+        user_table_count,
+        max_worker_processes,
+        current_max_workers,
+    )
+    targets["autovacuum"] = "on"
+    return targets
+
+
+def _global_parameter_rationale(parameter: str, load_level: str) -> str:
+    rationales = {
+        "autovacuum": "Autovacuum must stay enabled for cluster-wide dead tuple cleanup.",
+        "autovacuum_max_workers": (
+            f"Cluster load is {load_level}: increase worker capacity so autovacuum can keep up."
+        ),
+        "autovacuum_naptime": (
+            f"Cluster load is {load_level}: run the autovacuum launcher more frequently."
+        ),
+        "autovacuum_vacuum_scale_factor": (
+            "Lower the global vacuum trigger ratio so large tables do not accumulate excessive dead tuples."
+        ),
+        "autovacuum_analyze_scale_factor": (
+            "Lower the global analyze trigger ratio to refresh planner statistics sooner under write pressure."
+        ),
+        "autovacuum_vacuum_threshold": (
+            "Lower the base vacuum threshold so autovacuum starts sooner under cluster-wide dead tuple pressure."
+        ),
+        "autovacuum_analyze_threshold": (
+            "Lower the base analyze threshold so statistics refresh sooner under write-heavy load."
+        ),
+        "autovacuum_vacuum_cost_delay": (
+            "Reduce throttling so autovacuum workers reclaim dead tuples faster during high load."
+        ),
+        "autovacuum_vacuum_cost_limit": (
+            "Increase the autovacuum I/O budget so workers make progress when many tables are lagging."
+        ),
+        "log_autovacuum_min_duration": (
+            "Improve observability of long or frequent autovacuum runs while investigating backlog."
+        ),
+    }
+    return rationales.get(parameter, "Adjust this global autovacuum parameter for the current workload.")
+
+
+def _should_recommend_global_change(
+    parameter: str,
+    current_value: Any,
+    recommended_value: Any,
+) -> bool:
+    if parameter == "autovacuum":
+        return str(current_value).lower() not in {"on", "true", "1"}
+
+    if parameter == "autovacuum_max_workers":
+        return _parse_setting_int(recommended_value) > _parse_setting_int(current_value, 3)
+
+    if parameter == "autovacuum_naptime":
+        return _parse_setting_int(recommended_value, 60) < _parse_setting_int(current_value, 60)
+
+    if parameter.endswith("_scale_factor"):
+        return _parse_setting_float(recommended_value) < _parse_setting_float(current_value, 1.0) - 1e-9
+
+    if parameter.endswith("_threshold"):
+        current = _parse_setting_int(current_value, 50)
+        recommended = _parse_setting_int(recommended_value, 50)
+        return recommended < current
+
+    if parameter == "autovacuum_vacuum_cost_delay":
+        return _parse_setting_float(recommended_value) < _parse_setting_float(current_value, 2.0) - 1e-9
+
+    if parameter == "autovacuum_vacuum_cost_limit":
+        current = _parse_setting_int(current_value, -1)
+        recommended = _parse_setting_int(recommended_value, -1)
+        if recommended < 0:
+            return False
+        return current < 0 or recommended > current
+
+    if parameter == "log_autovacuum_min_duration":
+        current = str(current_value or "-1")
+        return current in {"-1", ""}
+
+    return str(current_value) != str(recommended_value)
+
+
+def build_global_autovacuum_recommendations(
+    *,
+    load_level: str,
+    metrics: dict[str, Any],
+    current_settings: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    user_table_count = int(metrics.get("user_table_count") or 0)
+    max_worker_processes = _parse_setting_int(
+        (current_settings.get("max_worker_processes") or {}).get("setting"),
+        8,
+    )
+    current_max_workers = _parse_setting_int(
+        (current_settings.get("autovacuum_max_workers") or {}).get("setting"),
+        3,
+    )
+
+    targets = build_global_autovacuum_targets(
+        load_level,
+        user_table_count=user_table_count,
+        max_worker_processes=max_worker_processes,
+        current_max_workers=current_max_workers,
+    )
+
+    recommendations: list[dict[str, Any]] = []
+    restart_required = False
+
+    for parameter, recommended_value in targets.items():
+        if parameter == "max_worker_processes":
+            continue
+
+        meta = current_settings.get(parameter) or {}
+        current_value = meta.get("setting", "")
+        if not _should_recommend_global_change(parameter, current_value, recommended_value):
+            continue
+
+        context = meta.get("context") or "sighup"
+        if context == "postmaster":
+            restart_required = True
+
+        recommendations.append(
+            {
+                "parameter": parameter,
+                "current_value": current_value,
+                "recommended_value": recommended_value,
+                "unit": meta.get("unit") or "",
+                "context": context,
+                "rationale": _global_parameter_rationale(parameter, load_level),
+                "sql": _build_alter_system_sql(parameter, recommended_value),
+                "risks": get_execution_risks(
+                    "alter_system",
+                    parameter=parameter,
+                    context=context,
+                ),
+            }
+        )
+
+    script_lines = [
+        "-- Global autovacuum tuning proposal based on current cluster load",
+        f"-- Detected load level: {load_level}",
+        "",
+    ]
+    script_lines.extend(item["sql"] for item in recommendations)
+    if recommendations:
+        script_lines.extend(
+            [
+                "",
+                "SELECT pg_reload_conf();",
+            ]
+        )
+        if restart_required:
+            script_lines.append("-- Restart required for postmaster-level parameters (autovacuum_max_workers).")
+
+    load_labels = {
+        "low": "Low maintenance pressure",
+        "medium": "Moderate maintenance pressure",
+        "high": "High maintenance pressure",
+        "critical": "Critical maintenance backlog",
+    }
+
+    return {
+        "load_level": load_level,
+        "load_label": load_labels.get(load_level, load_level.title()),
+        "metrics": metrics,
+        "recommendations": recommendations,
+        "restart_required": restart_required,
+        "script_sql": "\n".join(script_lines).strip(),
+        "reload_sql": "SELECT pg_reload_conf();",
+        "batch_risks": get_execution_risks("alter_system_batch"),
+        "reload_risks": get_execution_risks("reload_conf"),
+        "summary": (
+            f"{load_labels.get(load_level, load_level.title())}: "
+            f"{len(recommendations)} global parameter(s) proposed."
+        ),
+    }
+
+
+def run_global_autovacuum_tuning(
+    conn,
+    *,
+    catalog: list[dict[str, Any]] | None = None,
+    yaml_path: str | None = None,
+    flagged_table_count: int = 0,
+    critical_vacuum_count: int = 0,
+    elevated_vacuum_count: int = 0,
+) -> dict[str, Any]:
+    if catalog is None:
+        yaml_path = yaml_path or str(Path(__file__).resolve().parents[2] / "advisor_enriched.yml")
+        catalog = load_recommendation_catalog(yaml_path)
+
+    rows = json.loads(
+        db_fetch_json(conn, get_rule_sql(catalog, CLUSTER_LOAD_RULE_ID))
+    )
+    if not rows:
+        return {"ok": False, "error": "Unable to read cluster autovacuum metrics."}
+
+    row = rows[0]
+    settings_raw = row.get("autovacuum_settings") or {}
+    if isinstance(settings_raw, str):
+        settings_raw = json.loads(settings_raw)
+
+    current_settings = {
+        key: value for key, value in settings_raw.items() if isinstance(value, dict)
+    }
+
+    current_max_workers = _parse_setting_int(
+        (current_settings.get("autovacuum_max_workers") or {}).get("setting"),
+        3,
+    )
+    metrics = {
+        "user_table_count": int(row.get("user_table_count") or 0),
+        "total_dead_tuples": int(row.get("total_dead_tuples") or 0),
+        "total_live_tuples": int(row.get("total_live_tuples") or 0),
+        "high_dead_pressure_tables": int(row.get("high_dead_pressure_tables") or 0),
+        "never_vacuumed_tables": int(row.get("never_vacuumed_tables") or 0),
+        "never_analyzed_tables": int(row.get("never_analyzed_tables") or 0),
+        "active_autovacuum_workers": int(row.get("active_autovacuum_workers") or 0),
+        "flagged_table_count": flagged_table_count,
+        "critical_vacuum_count": critical_vacuum_count,
+        "elevated_vacuum_count": elevated_vacuum_count,
+    }
+
+    load_level = assess_cluster_load(
+        total_dead_tuples=metrics["total_dead_tuples"],
+        high_dead_pressure_tables=metrics["high_dead_pressure_tables"],
+        never_vacuumed_tables=metrics["never_vacuumed_tables"],
+        flagged_table_count=flagged_table_count,
+        critical_vacuum_count=critical_vacuum_count,
+        elevated_vacuum_count=elevated_vacuum_count,
+        active_autovacuum_workers=metrics["active_autovacuum_workers"],
+        current_max_workers=current_max_workers,
+        user_table_count=metrics["user_table_count"],
+    )
+
+    tuning = build_global_autovacuum_recommendations(
+        load_level=load_level,
+        metrics=metrics,
+        current_settings=current_settings,
+    )
+    tuning["ok"] = True
+    tuning["current_settings"] = {
+        name: meta.get("setting", "")
+        for name, meta in current_settings.items()
+        if name in GLOBAL_AUTOVACUUM_SETTINGS
+    }
+    return tuning
+
+
+def run_table_autovacuum_advisor(
+    db_config,
+    *,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    yaml_path: str | None = None,
+) -> dict[str, Any]:
+    stale_days = normalize_stale_days(stale_days)
+    yaml_path = yaml_path or str(Path(__file__).resolve().parents[2] / "advisor_enriched.yml")
+
+    conn, message = connectdb(db_config)
+    if conn is None:
+        return {"ok": False, "error": message or "Unable to connect.", "tables": []}
+
+    try:
+        catalog = load_recommendation_catalog(yaml_path)
+        vacuum_rule = _find_rule(catalog, VACUUM_URGENCY_RULE_ID)
+
+        flagged_sql = get_rule_sql(
+            catalog,
+            MAINTENANCE_FLAGGED_RULE_ID,
+            stale_days=stale_days,
+            min_table_size_bytes=DEFAULT_MIN_TABLE_BYTES,
+        )
+        stale_rows = json.loads(db_fetch_json(conn, flagged_sql))
+        vacuum_rows: list[dict[str, Any]] = []
+        if vacuum_rule and vacuum_rule.get("sql"):
+            vacuum_rows = json.loads(db_fetch_json(conn, vacuum_rule["sql"]))
+
+        vacuum_by_table = {
+            _table_key(row.get("schema_name", ""), row.get("table_name", "")): row
+            for row in vacuum_rows
+            if row.get("schema_name") and row.get("table_name")
+        }
+
+        tables: list[dict[str, Any]] = []
+        for row in stale_rows:
+            schema_name = str(row.get("schema_name") or "")
+            table_name = str(row.get("table_name") or row.get("object_name") or "")
+            if not schema_name or not table_name:
+                continue
+
+            key = _table_key(schema_name, table_name)
+            vacuum_info = vacuum_by_table.get(key, {})
+            never_analyzed = bool(row.get("never_analyzed"))
+            never_vacuumed = bool(row.get("never_vacuumed"))
+            issue_types = _normalize_issue_types(row.get("issue_types"))
+            if not issue_types:
+                issue_types = []
+                if never_analyzed:
+                    issue_types.append("never_analyzed")
+                elif row.get("stale_analyze"):
+                    issue_types.append("stale_analyze")
+                if never_vacuumed:
+                    issue_types.append("never_vacuumed")
+                elif row.get("stale_vacuum"):
+                    issue_types.append("stale_vacuum")
+            stats_age_days = row.get("stats_age_days")
+            vacuum_age_days = row.get("vacuum_age_days")
+            mod_ratio = float(row.get("modified_since_analyze_ratio") or 0)
+            vacuum_urgency = float(vacuum_info.get("vacuum_urgency") or 0)
+
+            analyze_sql = build_analyze_sql(schema_name, table_name)
+            vacuum_sql = build_vacuum_sql(schema_name, table_name)
+            alter_available = not never_analyzed
+            tuning = compute_autovacuum_tuning(
+                n_live_tup=int(row.get("n_live_tup") or 0),
+                n_dead_tup=int(row.get("n_dead_tup") or 0),
+                table_size_bytes=int(row.get("table_size_bytes") or 0),
+                modified_since_analyze_ratio=mod_ratio,
+                vacuum_urgency=vacuum_urgency,
+                never_analyzed=False,
+            )
+            if alter_available:
+                autovacuum_sql = build_autovacuum_tuning_sql(
+                    schema_name,
+                    table_name,
+                    n_live_tup=int(row.get("n_live_tup") or 0),
+                    n_dead_tup=int(row.get("n_dead_tup") or 0),
+                    table_size_bytes=int(row.get("table_size_bytes") or 0),
+                    modified_since_analyze_ratio=mod_ratio,
+                    vacuum_urgency=vacuum_urgency,
+                    never_analyzed=False,
+                )
+                tuning_rationale = build_tuning_rationale(
+                    n_live_tup=int(row.get("n_live_tup") or 0),
+                    n_dead_tup=int(row.get("n_dead_tup") or 0),
+                    table_size_bytes=int(row.get("table_size_bytes") or 0),
+                    modified_since_analyze_ratio=mod_ratio,
+                    vacuum_urgency=vacuum_urgency,
+                    never_analyzed=False,
+                )
+                alter_risks = get_execution_risks("alter_table", table_name=key)
+                alter_skip_reason = ""
+            else:
+                autovacuum_sql = ""
+                tuning_rationale = ""
+                alter_risks = []
+                alter_skip_reason = "Run ANALYZE first; autovacuum tuning requires planner statistics."
+
+            calculation_help = build_table_calculation_help(
+                stale_days=stale_days,
+                issue_types=issue_types,
+                priority=row.get("pga_recommendation_level") or "MEDIUM",
+                recommendation_note=row.get("recommendation_note") or "",
+                never_analyzed=never_analyzed,
+                stale_analyze=bool(row.get("stale_analyze")),
+                never_vacuumed=never_vacuumed,
+                stale_vacuum=bool(row.get("stale_vacuum")),
+                needs_vacuum_pressure=bool(row.get("needs_vacuum_pressure")),
+                stats_age_days=stats_age_days,
+                vacuum_age_days=vacuum_age_days,
+                n_live_tup=int(row.get("n_live_tup") or 0),
+                n_dead_tup=int(row.get("n_dead_tup") or 0),
+                n_mod_since_analyze=int(row.get("n_mod_since_analyze") or 0),
+                modified_since_analyze_pct=row.get("modified_since_analyze_pct"),
+                dead_tuple_pct=row.get("dead_tuple_pct"),
+                table_size_pretty=row.get("table_size_pretty") or "",
+                vacuum_urgency=vacuum_urgency,
+                alter_available=alter_available,
+                alter_skip_reason=alter_skip_reason,
+                tuning=tuning,
+            )
+
+            issue_type = _primary_issue_type(issue_types)
+            tables.append(
+                {
+                    "schema_name": schema_name,
+                    "table_name": table_name,
+                    "object_name": key,
+                    "issue_type": issue_type,
+                    "issue_types": issue_types,
+                    "priority": row.get("pga_recommendation_level") or "MEDIUM",
+                    "recommendation_note": row.get("recommendation_note") or "",
+                    "last_analyze": row.get("last_analyze"),
+                    "last_autoanalyze": row.get("last_autoanalyze"),
+                    "last_vacuum": row.get("last_vacuum"),
+                    "last_autovacuum": row.get("last_autovacuum"),
+                    "last_any_analyze": row.get("last_any_analyze"),
+                    "last_any_vacuum": row.get("last_any_vacuum"),
+                    "stats_age_days": stats_age_days,
+                    "vacuum_age_days": vacuum_age_days,
+                    "never_analyzed": never_analyzed,
+                    "never_vacuumed": never_vacuumed,
+                    "stale_analyze": bool(row.get("stale_analyze")),
+                    "stale_vacuum": bool(row.get("stale_vacuum")),
+                    "alter_available": alter_available,
+                    "alter_skip_reason": alter_skip_reason,
+                    "n_live_tup": row.get("n_live_tup"),
+                    "n_dead_tup": row.get("n_dead_tup"),
+                    "n_mod_since_analyze": row.get("n_mod_since_analyze"),
+                    "modified_since_analyze_pct": row.get("modified_since_analyze_pct"),
+                    "dead_tuple_pct": row.get("dead_tuple_pct"),
+                    "needs_vacuum_pressure": bool(row.get("needs_vacuum_pressure")),
+                    "table_size_pretty": row.get("table_size_pretty"),
+                    "table_size_bytes": row.get("table_size_bytes"),
+                    "vacuum_urgency": vacuum_info.get("vacuum_urgency"),
+                    "analyze_sql": analyze_sql,
+                    "vacuum_sql": vacuum_sql,
+                    "autovacuum_sql": autovacuum_sql,
+                    "tuning_rationale": tuning_rationale,
+                    "calculation_help": calculation_help,
+                    "script_sql": build_restore_script(analyze_sql, vacuum_sql, autovacuum_sql),
+                    "analyze_risks": get_execution_risks("analyze", table_name=key),
+                    "vacuum_risks": get_execution_risks("vacuum", table_name=key),
+                    "alter_risks": alter_risks,
+                }
+            )
+
+        tables.sort(
+            key=lambda item: (
+                ISSUE_SORT_ORDER.get(item["issue_type"], 99),
+                0 if item["priority"] == "HIGH" else 1 if item["priority"] == "MEDIUM" else 2,
+                -(item.get("n_live_tup") or 0),
+            )
+        )
+
+        critical_vacuum_count = sum(
+            1 for item in tables if float(item.get("vacuum_urgency") or 0) >= 2
+        )
+        elevated_vacuum_count = sum(
+            1 for item in tables if float(item.get("vacuum_urgency") or 0) >= 1
+        )
+        global_tuning = run_global_autovacuum_tuning(
+            conn,
+            catalog=catalog,
+            flagged_table_count=len(tables),
+            critical_vacuum_count=critical_vacuum_count,
+            elevated_vacuum_count=elevated_vacuum_count,
+        )
+
+        return {
+            "ok": True,
+            "error": "",
+            "stale_days": stale_days,
+            "criteria_help": build_criteria_help(stale_days),
+            "tables": tables,
+            "global_tuning": global_tuning,
+            "batch_actions": build_batch_actions(tables),
+            "summary": {
+                "total": len(tables),
+                "never_analyzed": sum(1 for t in tables if t.get("never_analyzed")),
+                "stale_analyze": sum(1 for t in tables if t.get("stale_analyze")),
+                "never_vacuumed": sum(1 for t in tables if t.get("never_vacuumed")),
+                "stale_vacuum": sum(1 for t in tables if t.get("stale_vacuum")),
+            },
+        }
+    except Exception as exc:
+        return {"ok": False, "error": str(exc), "tables": []}
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/apps/home/table_autovacuum_advisor.py
+++ b/apps/home/table_autovacuum_advisor.py
@@ -89,7 +89,7 @@ def build_analyze_sql(schema_name: str, table_name: str) -> str:
 
 
 def build_vacuum_sql(schema_name: str, table_name: str) -> str:
-    return f"VACUUM {_quote_ident(schema_name)}.{_quote_ident(table_name)};"
+    return f"VACUUM VERBOSE {_quote_ident(schema_name)}.{_quote_ident(table_name)};"
 
 
 def compute_autovacuum_tuning(
@@ -460,21 +460,31 @@ def build_criteria_help(stale_days: int = DEFAULT_STALE_DAYS) -> dict[str, Any]:
 
 
 def build_restore_script(analyze_sql: str, vacuum_sql: str, autovacuum_sql: str = "") -> str:
-    lines = [
-        "-- 1) Reclaim dead tuples (manual vacuum if autovacuum is lagging)",
-        vacuum_sql,
-        "",
-        "-- 2) Refresh planner statistics",
-        analyze_sql,
-    ]
+    lines: list[str] = []
+    step = 1
     if autovacuum_sql:
         lines.extend(
             [
-                "",
-                "-- 3) Tune per-table autovacuum thresholds",
+                f"-- {step}) Tune per-table autovacuum thresholds",
                 autovacuum_sql,
+                "",
             ]
         )
+        step += 1
+    lines.extend(
+        [
+            f"-- {step}) Refresh planner statistics",
+            analyze_sql,
+            "",
+        ]
+    )
+    step += 1
+    lines.extend(
+        [
+            f"-- {step}) Reclaim dead tuples (manual vacuum if autovacuum is lagging)",
+            vacuum_sql,
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -552,18 +562,18 @@ def get_batch_execution_risks(action: str, table_count: int = 0) -> list[str]:
     table_count = max(0, int(table_count or 0))
     risks: list[str] = []
 
-    if action in {"vacuum", "all"}:
-        risks.extend(get_execution_risks("vacuum"))
-    if action in {"analyze", "all"}:
-        risks.extend(get_execution_risks("analyze"))
     if action in {"alter", "all"}:
         risks.extend(get_execution_risks("alter_table"))
+    if action in {"analyze", "all"}:
+        risks.extend(get_execution_risks("analyze"))
+    if action in {"vacuum", "all"}:
+        risks.extend(get_execution_risks("vacuum"))
 
     labels = {
         "vacuum": "VACUUM",
         "analyze": "ANALYZE",
         "alter": "ALTER TABLE",
-        "all": "VACUUM, ANALYZE and ALTER TABLE",
+        "all": "ALTER TABLE, ANALYZE and VACUUM",
     }
     risks.append(
         f"Batch run: executes {labels.get(action, action)} sequentially on "
@@ -571,7 +581,7 @@ def get_batch_execution_risks(action: str, table_count: int = 0) -> list[str]:
     )
     risks.append("Total runtime and I/O can be significant; prefer a maintenance window.")
     if action == "all":
-        risks.append("Order is VACUUM → ANALYZE → ALTER TABLE for each flagged table group.")
+        risks.append("Order is ALTER TABLE → ANALYZE → VACUUM for each flagged table group.")
     if action == "alter":
         risks.append("ALTER TABLE changes persist until RESET or manual override.")
 

--- a/apps/static/assets/css/pga.css
+++ b/apps/static/assets/css/pga.css
@@ -2,13 +2,28 @@
     background-color: inherit;
 }
 
+:root {
+    --pga-sidebar-width: 280px;
+}
+
 #sidebarMenu {
-    max-width: 300px;
+    width: var(--pga-sidebar-width);
+    max-width: var(--pga-sidebar-width);
 }
 
 @media (min-width: 992px) {
     .content, footer {
-        margin-left: 300px;
+        margin-left: var(--pga-sidebar-width) !important;
+    }
+}
+
+@media (max-width: 991.98px) {
+    #sidebarMenu.pga-sidebar {
+        z-index: 1050;
+    }
+
+    .content, footer {
+        margin-left: 0 !important;
     }
 }
 

--- a/apps/static/assets/css/pgassistant.css
+++ b/apps/static/assets/css/pgassistant.css
@@ -2138,6 +2138,35 @@ body {
   padding: 1rem;
 }
 
+.connect-option-help {
+  border-top: 1px solid var(--pga-border-soft, #e8eef5);
+}
+
+.connect-option-help-title {
+  color: var(--pga-text, #0f172a);
+  font-size: .84rem;
+  font-weight: 850;
+  margin-bottom: .55rem;
+}
+
+.connect-option-help-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: #475569;
+  font-size: .84rem;
+  line-height: 1.45;
+}
+
+.connect-option-help-list li + li {
+  margin-top: .45rem;
+}
+
+.connect-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
 .form-label,
 .label-with-help {
   color: #475569;
@@ -3772,6 +3801,98 @@ body {
 
   #sidebarMenu #app-title:hover {
     transform: none;
+  }
+
+  #sidebarMenu .pga-sidebar-db-wrap {
+    margin: .35rem 0 .85rem;
+    padding: 0 .15rem;
+  }
+
+  #sidebarMenu .pga-sidebar-db-panel {
+    display: flex;
+    flex-direction: column;
+    gap: .55rem;
+    padding: .75rem .85rem;
+    border: 1px solid var(--pga-sidebar-border);
+    border-radius: .85rem;
+    background: rgba(255, 255, 255, .04);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04);
+  }
+
+  #sidebarMenu .pga-sidebar-db-meta {
+    display: flex;
+    flex-direction: column;
+    gap: .2rem;
+    min-width: 0;
+  }
+
+  #sidebarMenu .pga-sidebar-db-label {
+    font-size: .66rem;
+    font-weight: 800;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--pga-sidebar-muted);
+  }
+
+  #sidebarMenu .pga-sidebar-db-value {
+    color: var(--pga-sidebar-text);
+    font-size: .82rem;
+    font-weight: 700;
+    line-height: 1.35;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #sidebarMenu .pga-sidebar-db-value strong {
+    color: #fff;
+    font-weight: 800;
+  }
+
+  #sidebarMenu .pga-sidebar-db-static {
+    display: block;
+    width: 100%;
+    min-height: 34px;
+    padding: .375rem .65rem;
+    border: 1px solid rgba(255, 255, 255, .12);
+    border-radius: .65rem;
+    background: rgba(15, 23, 42, .35);
+    color: var(--pga-sidebar-text);
+    font-size: .84rem;
+    font-weight: 700;
+    line-height: 1.35;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #sidebarMenu .pga-multi-db-filter--sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+    width: 100%;
+  }
+
+  #sidebarMenu .pga-multi-db-filter--sidebar .pga-multi-db-form {
+    width: 100%;
+  }
+
+  #sidebarMenu .pga-multi-db-select {
+    width: 100%;
+    min-height: 34px;
+    border: 1px solid rgba(255, 255, 255, .12);
+    border-radius: .65rem;
+    background: rgba(15, 23, 42, .35);
+    color: var(--pga-sidebar-text);
+    font-size: .84rem;
+    font-weight: 700;
+  }
+
+  #sidebarMenu .pga-multi-db-select:focus {
+    border-color: rgba(56, 189, 248, .55);
+    box-shadow: 0 0 0 .15rem rgba(56, 189, 248, .15);
+    background: rgba(15, 23, 42, .5);
+    color: #fff;
   }
 
   #sidebarMenu .btn-upgrade-pro {

--- a/apps/static/assets/css/pgassistant.css
+++ b/apps/static/assets/css/pgassistant.css
@@ -3712,10 +3712,14 @@ body {
       radial-gradient(circle at 15% 0%, rgba(57, 189, 248, .16), transparent 32%),
       linear-gradient(180deg, var(--pga-sidebar-bg-2) 0%, var(--pga-sidebar-bg) 100%) !important;
     border-right: 1px solid var(--pga-sidebar-border);
+    width: var(--pga-sidebar-width, 280px);
+    max-width: var(--pga-sidebar-width, 280px);
+    z-index: 1030;
   }
 
   #sidebarMenu .sidebar-inner {
     min-height: 100vh;
+    overflow-x: hidden;
   }
 
   #sidebarMenu .nav-link {
@@ -3804,29 +3808,103 @@ body {
   }
 
   #sidebarMenu .pga-sidebar-db-wrap {
-    margin: .35rem 0 .85rem;
+    margin: .35rem 0 1rem;
     padding: 0 .15rem;
+    white-space: normal;
+    overflow: hidden;
+    max-width: 100%;
   }
 
   #sidebarMenu .pga-sidebar-db-panel {
     display: flex;
     flex-direction: column;
+    gap: .65rem;
+    padding: .75rem .8rem;
+    border: 1px solid rgba(56, 189, 248, .22);
+    border-radius: .95rem;
+    background:
+      linear-gradient(145deg, rgba(56, 189, 248, .08) 0%, rgba(255, 255, 255, .03) 42%, rgba(15, 23, 42, .18) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, .07),
+      0 10px 24px rgba(2, 8, 23, .22);
+    white-space: normal;
+    overflow: hidden;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  #sidebarMenu .pga-sidebar-db-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    padding-bottom: .55rem;
+    border-bottom: 1px solid rgba(255, 255, 255, .08);
+  }
+
+  #sidebarMenu .pga-sidebar-db-status {
+    display: inline-flex;
+    align-items: center;
+    gap: .45rem;
+    min-width: 0;
+  }
+
+  .pga-conn-dot,
+  #sidebarMenu .pga-conn-dot,
+  #sidebarMenu .pga-sidebar-db-dot {
+    width: .55rem;
+    height: .55rem;
+    border-radius: 999px;
+    background: #34d399;
+    box-shadow: 0 0 0 3px rgba(52, 211, 153, .18);
+    animation: pga-sidebar-db-pulse 2.4s ease-in-out infinite;
+    flex-shrink: 0;
+  }
+
+  @keyframes pga-sidebar-db-pulse {
+    0%, 100% { box-shadow: 0 0 0 3px rgba(52, 211, 153, .18); }
+    50% { box-shadow: 0 0 0 5px rgba(52, 211, 153, .08); }
+  }
+
+  #sidebarMenu .pga-sidebar-db-status-text {
+    color: #ecfdf5;
+    font-size: .74rem;
+    font-weight: 800;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+  }
+
+  #sidebarMenu .pga-sidebar-db-pg-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: .18rem .5rem;
+    border-radius: 999px;
+    border: 1px solid rgba(56, 189, 248, .35);
+    background: rgba(56, 189, 248, .12);
+    color: #bae6fd;
+    font-size: .68rem;
+    font-weight: 800;
+    letter-spacing: .03em;
+    white-space: nowrap;
+  }
+
+  #sidebarMenu .pga-sidebar-db-body {
+    display: flex;
+    flex-direction: column;
     gap: .55rem;
-    padding: .75rem .85rem;
-    border: 1px solid var(--pga-sidebar-border);
-    border-radius: .85rem;
-    background: rgba(255, 255, 255, .04);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04);
   }
 
   #sidebarMenu .pga-sidebar-db-meta {
     display: flex;
     flex-direction: column;
-    gap: .2rem;
+    gap: .22rem;
     min-width: 0;
   }
 
   #sidebarMenu .pga-sidebar-db-label {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
     font-size: .66rem;
     font-weight: 800;
     letter-spacing: .08em;
@@ -3834,14 +3912,42 @@ body {
     color: var(--pga-sidebar-muted);
   }
 
+  #sidebarMenu .pga-sidebar-db-label .bi {
+    font-size: .72rem;
+    opacity: .85;
+  }
+
   #sidebarMenu .pga-sidebar-db-value {
     color: var(--pga-sidebar-text);
-    font-size: .82rem;
+    font-size: .8rem;
     font-weight: 700;
     line-height: 1.35;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: 100%;
+    display: block;
+  }
+
+  @media (min-width: 992px) and (max-width: 1280px) {
+    #sidebarMenu .pga-sidebar-db-value,
+    #sidebarMenu .pga-sidebar-db-static {
+      white-space: normal;
+      word-break: break-all;
+      overflow-wrap: anywhere;
+      text-overflow: unset;
+    }
+
+    #sidebarMenu .pga-sidebar-db-foot {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: .35rem;
+    }
+
+    #sidebarMenu .pga-sidebar-db-head {
+      flex-wrap: wrap;
+      gap: .35rem;
+    }
   }
 
   #sidebarMenu .pga-sidebar-db-value strong {
@@ -3853,17 +3959,72 @@ body {
     display: block;
     width: 100%;
     min-height: 34px;
-    padding: .375rem .65rem;
-    border: 1px solid rgba(255, 255, 255, .12);
+    padding: .4rem .65rem;
+    border: 1px solid rgba(255, 255, 255, .14);
     border-radius: .65rem;
-    background: rgba(15, 23, 42, .35);
-    color: var(--pga-sidebar-text);
+    background: rgba(15, 23, 42, .42);
+    color: #f8fafc;
     font-size: .84rem;
     font-weight: 700;
     line-height: 1.35;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  #sidebarMenu .pga-sidebar-db-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    padding-top: .15rem;
+  }
+
+  #sidebarMenu .pga-sidebar-db-mode-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: .22rem .55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(167, 139, 250, .35);
+    background: rgba(139, 92, 246, .14);
+    color: #ddd6fe;
+    font-size: .68rem;
+    font-weight: 800;
+    letter-spacing: .02em;
+  }
+
+  #sidebarMenu .pga-sidebar-db-count {
+    color: var(--pga-sidebar-muted);
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+  }
+
+  #sidebarMenu .pga-sidebar-db-settings {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .4rem;
+    width: 100%;
+    margin-top: .1rem;
+    padding: .42rem .65rem;
+    border: 1px solid rgba(255, 255, 255, .12);
+    border-radius: .65rem;
+    background: rgba(255, 255, 255, .04);
+    color: var(--pga-sidebar-text);
+    font-size: .76rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: background-color .15s ease, border-color .15s ease, color .15s ease, transform .15s ease;
+  }
+
+  #sidebarMenu .pga-sidebar-db-settings:hover {
+    background: rgba(255, 255, 255, .09);
+    border-color: rgba(56, 189, 248, .35);
+    color: #fff;
+    transform: translateY(-1px);
   }
 
   #sidebarMenu .pga-multi-db-filter--sidebar {
@@ -3880,19 +4041,218 @@ body {
   #sidebarMenu .pga-multi-db-select {
     width: 100%;
     min-height: 34px;
-    border: 1px solid rgba(255, 255, 255, .12);
+    padding-right: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, .14);
     border-radius: .65rem;
-    background: rgba(15, 23, 42, .35);
-    color: var(--pga-sidebar-text);
+    background-color: rgba(15, 23, 42, .42);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cbd5e1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right .65rem center;
+    background-size: 12px 10px;
+    color: #f8fafc;
     font-size: .84rem;
     font-weight: 700;
+    appearance: none;
+  }
+
+  #sidebarMenu .pga-multi-db-select option {
+    color: #0f172a;
+    background: #fff;
   }
 
   #sidebarMenu .pga-multi-db-select:focus {
     border-color: rgba(56, 189, 248, .55);
     box-shadow: 0 0 0 .15rem rgba(56, 189, 248, .15);
-    background: rgba(15, 23, 42, .5);
+    background-color: rgba(15, 23, 42, .55);
     color: #fff;
+    outline: 0;
+  }
+
+  /* Compact connection bar — visible below top nav on small screens */
+  .pga-mobile-db-bar {
+    display: block;
+    padding: .75rem .85rem .85rem;
+    border: 1px solid rgba(56, 189, 248, .22);
+    border-radius: 0 0 1rem 1rem;
+    background:
+      linear-gradient(145deg, rgba(56, 189, 248, .10) 0%, rgba(255, 255, 255, .96) 38%, rgba(248, 250, 252, .98) 100%);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, .08);
+  }
+
+  .pga-mobile-db-bar-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .55rem;
+  }
+
+  .pga-mobile-db-status {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .4rem;
+    min-width: 0;
+  }
+
+  .pga-mobile-db-status-text {
+    color: #166534;
+    font-size: .72rem;
+    font-weight: 800;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+  }
+
+  .pga-mobile-db-pg {
+    display: inline-flex;
+    align-items: center;
+    padding: .15rem .45rem;
+    border-radius: 999px;
+    border: 1px solid rgba(56, 189, 248, .28);
+    background: rgba(56, 189, 248, .10);
+    color: #0369a1;
+    font-size: .66rem;
+    font-weight: 800;
+  }
+
+  .pga-mobile-db-settings-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+    border: 1px solid rgba(148, 163, 184, .28);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .85);
+    color: #475569;
+    text-decoration: none;
+    transition: background-color .15s ease, border-color .15s ease, color .15s ease;
+  }
+
+  .pga-mobile-db-settings-btn:hover {
+    color: #1d4ed8;
+    border-color: rgba(59, 130, 246, .35);
+    background: #eff6ff;
+  }
+
+  .pga-mobile-db-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .4rem;
+    margin-bottom: .55rem;
+  }
+
+  .pga-mobile-db-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    max-width: 100%;
+    min-width: 0;
+    padding: .28rem .55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, .24);
+    background: rgba(255, 255, 255, .82);
+    color: #334155;
+    font-size: .74rem;
+    font-weight: 700;
+  }
+
+  .pga-mobile-db-chip-mode {
+    color: #6d28d9;
+    border-color: rgba(167, 139, 250, .35);
+    background: rgba(139, 92, 246, .08);
+  }
+
+  .pga-mobile-db-chip-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .pga-mobile-db-name {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+    min-width: 0;
+    padding: .45rem .65rem;
+    border-radius: .65rem;
+    border: 1px solid rgba(148, 163, 184, .24);
+    background: rgba(255, 255, 255, .88);
+    color: #0f172a;
+    font-size: .84rem;
+    font-weight: 800;
+  }
+
+  .pga-mobile-db-name span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .pga-multi-db-filter--mobile {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+    width: 100%;
+  }
+
+  .pga-mobile-db-select-label {
+    font-size: .66rem;
+    font-weight: 800;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: #64748b;
+  }
+
+  .pga-multi-db-select--mobile {
+    width: 100%;
+    min-height: 38px;
+    border: 1px solid rgba(148, 163, 184, .28);
+    border-radius: .65rem;
+    background: rgba(255, 255, 255, .92);
+    color: #0f172a;
+    font-size: .84rem;
+    font-weight: 700;
+  }
+
+  .pga-multi-db-select--mobile:focus {
+    border-color: rgba(59, 130, 246, .45);
+    box-shadow: 0 0 0 .15rem rgba(59, 130, 246, .12);
+  }
+
+  @media (max-width: 991.98px) {
+    #sidebarMenu .sidebar-inner {
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+
+    #sidebarMenu .nav {
+      white-space: normal;
+    }
+
+    #sidebarMenu .pga-sidebar-db-wrap {
+      display: none !important;
+    }
+  }
+
+  @media (max-width: 575.98px) {
+    .pga-mobile-db-bar {
+      padding: .65rem .7rem .75rem;
+      border-radius: 0 0 .85rem .85rem;
+    }
+
+    .pga-mobile-db-grid {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .pga-mobile-db-chip {
+      max-width: none;
+      width: 100%;
+    }
   }
 
   #sidebarMenu .btn-upgrade-pro {

--- a/apps/templates/home/dashboard.html
+++ b/apps/templates/home/dashboard.html
@@ -144,6 +144,10 @@
         <span class="dashboard-action-main"><i class="bi bi-trophy"></i> Prioritize queries</span>
         <span class="dashboard-action-meta">ranking</span>
       </a>
+      <a href="/table_autovacuum_tune.html" class="dashboard-action-pill">
+        <span class="dashboard-action-main"><i class="bi bi-sliders2"></i> Autovacuum tuning</span>
+        <span class="dashboard-action-meta">per table</span>
+      </a>
       <a href="/pgtune.html" class="dashboard-action-pill">
         <span class="dashboard-action-main"><i class="bi bi-sliders"></i> Check configuration</span>
         <span class="dashboard-action-meta">pgTune</span>
@@ -166,16 +170,22 @@
     <div class="pg-card pg-card-body dashboard-kpi-card">
       <div class="dashboard-kpi-icon"><i class="bi bi-hdd-rack"></i></div>
       <div>
-        <div class="dashboard-kpi-label">Database size</div>
+        <div class="dashboard-kpi-label">{% if dbinfo.get('multi_db') %}Cluster size{% else %}Database size{% endif %}</div>
         <h2 class="dashboard-kpi-value">{{ dbinfo['size'] }}</h2>
-        <p class="dashboard-kpi-subtext">Shared buffers: <a href="/pgtune.html" class="text-decoration-none"><strong>{{ dbinfo['shared_buffers'] }}</strong></a></p>
+        <p class="dashboard-kpi-subtext">
+          {% if dbinfo.get('multi_db') %}
+          {{ dbinfo.get('databases', [])|length }} databases on cluster
+          {% else %}
+          Shared buffers: <a href="/pgtune.html" class="text-decoration-none"><strong>{{ dbinfo['shared_buffers'] }}</strong></a>
+          {% endif %}
+        </p>
       </div>
     </div>
 
     <div class="pg-card pg-card-body dashboard-kpi-card">
       <div class="dashboard-kpi-icon"><i class="bi bi-speedometer2"></i></div>
       <div>
-        <div class="dashboard-kpi-label">Hit cache ratio</div>
+        <div class="dashboard-kpi-label">{% if dbinfo.get('multi_db') %}Cluster hit cache{% else %}Hit cache ratio{% endif %}</div>
         <a href="/cache_table.html" class="text-decoration-none">
           <h2 class="dashboard-kpi-value">{{ dbinfo['cache'] }}%</h2>
         </a>
@@ -198,6 +208,29 @@
       </div>
     </div>
   </div>
+
+  {% if dbinfo.get('multi_db') and dbinfo.get('databases') %}
+  <div class="pg-card mb-4">
+    <div class="dashboard-card-header">
+      <span class="dashboard-section-title"><i class="bi bi-collection"></i><span>Cluster databases</span></span>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-sm mb-0">
+        <thead><tr><th>Database</th><th>Owner</th><th>Encoding</th><th class="text-end">Size</th></tr></thead>
+        <tbody>
+          {% for db in dbinfo.databases %}
+          <tr{% if db.is_connected %} class="table-primary-subtle"{% endif %}>
+            <td>{{ db.name }}{% if db.is_connected %} <span class="badge bg-primary-subtle text-primary">connected</span>{% endif %}</td>
+            <td>{{ db.owner }}</td>
+            <td>{{ db.encoding }}</td>
+            <td class="text-end">{{ db.size_pretty }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
 
   <div class="dashboard-section-grid">
     <div class="dashboard-main-grid">

--- a/apps/templates/home/dashboard.html
+++ b/apps/templates/home/dashboard.html
@@ -210,26 +210,26 @@
   </div>
 
   {% if dbinfo.get('multi_db') and dbinfo.get('databases') %}
-  <div class="pg-card mb-4">
+  <div class="pg-card mb-4" id="cluster-databases-card">
     <div class="dashboard-card-header">
       <span class="dashboard-section-title"><i class="bi bi-collection"></i><span>Cluster databases</span></span>
+      <div class="d-flex align-items-center flex-wrap gap-2">
+        <label for="cluster-db-per-page" class="small text-muted mb-0">Per page</label>
+        <select id="cluster-db-per-page" class="form-select form-select-sm" style="width: auto;">
+          <option value="5">5</option>
+          <option value="10" selected>10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </select>
+      </div>
     </div>
-    <div class="table-responsive">
-      <table class="table table-sm mb-0">
-        <thead><tr><th>Database</th><th>Owner</th><th>Encoding</th><th class="text-end">Size</th></tr></thead>
-        <tbody>
-          {% for db in dbinfo.databases %}
-          <tr{% if db.is_connected %} class="table-primary-subtle"{% endif %}>
-            <td>{{ db.name }}{% if db.is_connected %} <span class="badge bg-primary-subtle text-primary">connected</span>{% endif %}</td>
-            <td>{{ db.owner }}</td>
-            <td>{{ db.encoding }}</td>
-            <td class="text-end">{{ db.size_pretty }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+    <div class="pg-card-body dashboard-row-list" id="cluster-databases-list"></div>
+    <div class="pagination-wrapper px-3 pb-3 pt-0">
+      <div id="cluster-db-pagination-info" class="pagination-info"></div>
+      <div id="cluster-db-pagination-controls" class="pagination-controls"></div>
     </div>
   </div>
+  <script type="application/json" id="cluster-databases-json">{{ dbinfo.databases | tojson }}</script>
   {% endif %}
 
   <div class="dashboard-section-grid">
@@ -499,7 +499,112 @@
     }
 
     loadDevAdvisorSummary();
+    initClusterDatabasesPagination();
   });
+
+  function initClusterDatabasesPagination() {
+    const dataEl = document.getElementById("cluster-databases-json");
+    const listEl = document.getElementById("cluster-databases-list");
+    const perPageSelect = document.getElementById("cluster-db-per-page");
+    const paginationInfo = document.getElementById("cluster-db-pagination-info");
+    const paginationControls = document.getElementById("cluster-db-pagination-controls");
+    if (!dataEl || !listEl || !perPageSelect) {
+      return;
+    }
+
+    const databases = JSON.parse(dataEl.textContent || "[]");
+    let currentPage = 1;
+
+    function escapeHtml(value) {
+      const div = document.createElement("div");
+      div.textContent = value == null ? "" : String(value);
+      return div.innerHTML;
+    }
+
+    function pageSize() {
+      return Number(perPageSelect.value || 10);
+    }
+
+    function pageButton(label, page, active, disabled) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-sm " + (active ? "btn-primary" : "btn-outline-primary");
+      button.textContent = label;
+      button.disabled = disabled;
+      if (!disabled) {
+        button.addEventListener("click", function () {
+          currentPage = page;
+          renderClusterDatabases();
+          document.getElementById("cluster-databases-card")?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        });
+      }
+      return button;
+    }
+
+    function renderClusterDatabases() {
+      const size = pageSize();
+      const totalPages = Math.max(1, Math.ceil(databases.length / size));
+      if (currentPage > totalPages) {
+        currentPage = totalPages;
+      }
+
+      const start = (currentPage - 1) * size;
+      const end = Math.min(start + size, databases.length);
+      const pageItems = databases.slice(start, end);
+
+      if (!pageItems.length) {
+        listEl.innerHTML = '<div class="small text-muted">No databases found on this cluster.</div>';
+      } else {
+        listEl.innerHTML = pageItems.map(function (db) {
+          const connectedBadge = db.is_connected
+            ? ' <span class="badge bg-primary-subtle text-primary ms-1">connected</span>'
+            : "";
+          return '<div class="dashboard-row-item">'
+            + '<div class="dashboard-row-icon"><i class="bi bi-database"></i></div>'
+            + '<div class="dashboard-row-main">'
+            + '<div class="dashboard-row-label">' + escapeHtml(db.name) + connectedBadge + '</div>'
+            + '<div class="dashboard-row-note">' + escapeHtml(db.owner) + ' · ' + escapeHtml(db.encoding) + '</div>'
+            + '</div>'
+            + '<div class="dashboard-row-value">' + escapeHtml(db.size_pretty) + '</div>'
+            + '</div>';
+        }).join("");
+      }
+
+      if (paginationInfo) {
+        if (!databases.length) {
+          paginationInfo.textContent = "0 databases";
+        } else {
+          paginationInfo.textContent = "Showing " + (start + 1) + "-" + end + " of " + databases.length + " databases";
+        }
+      }
+
+      if (paginationControls) {
+        paginationControls.innerHTML = "";
+        if (totalPages <= 1) {
+          return;
+        }
+        paginationControls.appendChild(pageButton("Previous", currentPage - 1, false, currentPage <= 1));
+        for (let page = 1; page <= totalPages; page += 1) {
+          if (page === 1 || page === totalPages || Math.abs(page - currentPage) <= 2) {
+            paginationControls.appendChild(pageButton(String(page), page, page === currentPage, false));
+          } else if (page === currentPage - 3 || page === currentPage + 3) {
+            const ellipsis = document.createElement("span");
+            ellipsis.className = "btn btn-sm btn-light disabled";
+            ellipsis.textContent = "…";
+            paginationControls.appendChild(ellipsis);
+          }
+        }
+        paginationControls.appendChild(pageButton("Next", currentPage + 1, false, currentPage >= totalPages));
+      }
+    }
+
+    perPageSelect.addEventListener("change", function () {
+      currentPage = 1;
+      renderClusterDatabases();
+    });
+
+    renderClusterDatabases();
+  }
 
   function appendTextBlock(container, className, text) {
     if (!text) {

--- a/apps/templates/home/database.html
+++ b/apps/templates/home/database.html
@@ -7,10 +7,11 @@
 {% endblock stylesheets %}
 
 {% block content %}
+{% set conn = connection_form if connection_form is defined else session %}
 <div class="container-fluid py-4 pg-page connect-page">
   <div class="connect-layout">
 
-    {% if dbinfo['error'] %}
+    {% if dbinfo.get('error') %}
     <div id="database-error" class="alert connect-error-alert d-flex align-items-start mb-4" role="alert">
       <div class="connect-error-icon flex-shrink-0" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 20 20">
@@ -48,7 +49,7 @@
               <input
                 class="form-control no-validate"
                 id="db_uri"
-                value="{{ session.get('db_uri', '') }}"
+                value="{{ conn.get('db_uri', '') }}"
                 name="db_uri"
                 type="text"
                 placeholder="postgresql://user:password@host:5432/dbname"
@@ -68,7 +69,7 @@
                   <label for="db_host" class="form-label">Host name</label>
                   <input
                     class="form-control"
-                    value="{{ session.get('db_host', '') }}"
+                    value="{{ conn.get('db_host', '') }}"
                     id="db_host"
                     name="db_host"
                     type="text"
@@ -81,7 +82,7 @@
                   <label for="db_port" class="form-label">Port</label>
                   <input
                     class="form-control"
-                    value="{{ session.get('db_port', '') }}"
+                    value="{{ conn.get('db_port', '') }}"
                     id="db_port"
                     name="db_port"
                     type="number"
@@ -96,7 +97,7 @@
                   <label for="db_name" class="form-label">Database name</label>
                   <input
                     class="form-control"
-                    value="{{ session.get('db_name', '') }}"
+                    value="{{ conn.get('db_name', '') }}"
                     id="db_name"
                     name="db_name"
                     type="text"
@@ -109,7 +110,7 @@
                   <label for="db_user" class="form-label">User</label>
                   <input
                     class="form-control"
-                    value="{{ session.get('db_user', '') }}"
+                    value="{{ conn.get('db_user', '') }}"
                     id="db_user"
                     name="db_user"
                     type="text"
@@ -122,7 +123,7 @@
                   <label for="db_password" class="form-label">Password</label>
                   <input
                     class="form-control"
-                    value="{{ session['db_password'] }}"
+                    value="{{ conn.get('db_password', '') if connection_form is defined else session.get('db_password', '') }}"
                     id="db_password"
                     name="db_password"
                     type="password"
@@ -135,6 +136,14 @@
           </div>
 
           <div class="connect-actions">
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" id="multi_db" name="multi_db"
+                     {% if (connection_form.multi_db if connection_form is defined else session.get('multi_db')) %}checked{% endif %}>
+              <label class="form-check-label" for="multi_db">
+                Multi-database mode
+              </label>
+              <div class="form-text">Aggregate cluster stats on the dashboard and enable a database filter on schema pages.</div>
+            </div>
             <button id="connect" class="btn btn-primary" type="submit">
               Connect
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="ms-1" fill="currentColor" viewBox="0 0 20 20">

--- a/apps/templates/home/database.html
+++ b/apps/templates/home/database.html
@@ -135,15 +135,47 @@
             </div>
           </div>
 
-          <div class="connect-actions">
-            <div class="form-check mb-3">
-              <input class="form-check-input" type="checkbox" id="multi_db" name="multi_db"
-                     {% if (connection_form.multi_db if connection_form is defined else session.get('multi_db')) %}checked{% endif %}>
-              <label class="form-check-label" for="multi_db">
-                Multi-database mode
-              </label>
-              <div class="form-text">Aggregate cluster stats on the dashboard and enable a database filter on schema pages.</div>
+          <div class="mb-4 mt-4">
+            <div class="connect-section-title">Connection options</div>
+            <div class="connect-subtle-box">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="multi_db" name="multi_db"
+                       {% if (connection_form.multi_db if connection_form is defined else session.get('multi_db')) %}checked{% endif %}>
+                <label class="form-check-label fw-semibold" for="multi_db">
+                  Multi-database mode
+                </label>
+                <div class="form-text mt-1">
+                  Explore the whole PostgreSQL cluster from a single connection instead of one database only.
+                  Connect to any database on the instance (usually <code>postgres</code>); pgAssistant lists all
+                  non-template databases on that server.
+                </div>
+              </div>
+
+              <div class="connect-option-help mt-3 pt-3">
+                <div class="connect-option-help-title">Where to find it after connecting</div>
+                <ul class="connect-option-help-list mb-2">
+                  <li>
+                    <strong>Dashboard</strong> — cluster-wide KPIs and a <em>Cluster databases</em> list with size,
+                    owner, and the currently connected database.
+                  </li>
+                  <li>
+                    <strong>Left sidebar</strong> — under <em>PG Assistant</em>, the cluster host and a
+                    <em>Database</em> dropdown to switch the active database without reconnecting.
+                  </li>
+                  <li>
+                    <strong>Schema and tuning pages</strong> — scoped to the selected database on query activity,
+                    top queries, query/index advisors, and table autovacuum tuning
+                    (<code>pg_stat_statements</code> filter).
+                  </li>
+                </ul>
+                <div class="form-text mb-0">
+                  Leave this unchecked for the classic single-database workflow (one database name, no cluster filter).
+                </div>
+              </div>
             </div>
+          </div>
+
+          <div class="connect-actions">
             <button id="connect" class="btn btn-primary" type="submit">
               Connect
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" class="ms-1" fill="currentColor" viewBox="0 0 20 20">

--- a/apps/templates/home/generic.html
+++ b/apps/templates/home/generic.html
@@ -315,7 +315,8 @@
       const result = await response.json();
 
       if (result.success) {
-        modalResults.innerHTML = `<div class="text-success"><strong>Success</strong></div><div class="mt-2">${escapeHtml(result.message || "Query executed successfully.")}</div>`;
+        const output = result.output || result.message || "Query executed successfully.";
+        modalResults.innerHTML = `<div class="text-success"><strong>Success</strong></div><div class="mt-2">${escapeHtml(output)}</div>`;
       } else {
         modalResults.innerHTML = `<div class="text-danger"><strong>Error</strong></div><div class="mt-2">${escapeHtml(result.error || "Unknown error.")}</div>`;
       }

--- a/apps/templates/home/query_index_advisor.html
+++ b/apps/templates/home/query_index_advisor.html
@@ -141,6 +141,7 @@
       <h1 class="pg-title">Index Advisor</h1>
       <p class="pg-subtitle">
         Runs PostgreSQL generic plans for the top ranked queries, then checks whether safe index recommendations are available.
+        {% if multi_db_filter %}<span class="d-block mt-1">Database filter: <strong>{{ active_db }}</strong></span>{% endif %}
       </p>
     </div>
 
@@ -358,7 +359,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
   async function loadAdvisor() {
     try {
-      const response = await fetch("/api/v1/query_index_advisor", {
+      const advisorUrl = {% if multi_db_filter and active_db %}
+        "/api/v1/query_index_advisor?db={{ active_db | urlencode }}"
+      {% else %}
+        "/api/v1/query_index_advisor"
+      {% endif %};
+      const response = await fetch(advisorUrl, {
         method: "GET",
         headers: { "Accept": "application/json" }
       });

--- a/apps/templates/home/query_parameter_advisor.html
+++ b/apps/templates/home/query_parameter_advisor.html
@@ -174,6 +174,7 @@
       <p class="pg-subtitle">
         Runs generic plans for the pg_stat_statements workload, aggregates plan and runtime signals,
         then highlights the pgTune parameters worth reviewing.
+        {% if multi_db_filter %}<span class="d-block mt-1">Database filter: <strong>{{ active_db }}</strong></span>{% endif %}
       </p>
     </div>
 
@@ -405,7 +406,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
   async function loadAdvisor() {
     try {
-      const response = await fetch("/api/v1/query_parameter_advisor", {
+      const advisorUrl = {% if multi_db_filter and active_db %}
+        "/api/v1/query_parameter_advisor?db={{ active_db | urlencode }}"
+      {% else %}
+        "/api/v1/query_parameter_advisor"
+      {% endif %};
+      const response = await fetch(advisorUrl, {
         method: "GET",
         headers: { "Accept": "application/json" }
       });

--- a/apps/templates/home/rankqueries.html
+++ b/apps/templates/home/rankqueries.html
@@ -57,6 +57,7 @@
       <p class="pg-subtitle">
         Prioritize the queries that deserve investigation first. Scores are relative to the current workload snapshot
         and should be interpreted with execution pattern and business context.
+        {% if multi_db_filter %}<span class="d-block mt-1">Database filter: <strong>{{ active_db }}</strong></span>{% endif %}
       </p>
     </div>
 

--- a/apps/templates/home/table_autovacuum_tune.html
+++ b/apps/templates/home/table_autovacuum_tune.html
@@ -1,0 +1,1221 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}Table autovacuum tuning{% endblock %}
+
+{% block stylesheets %}
+<link rel="stylesheet" href="{{ config.ASSETS_ROOT }}/css/pgassistant.css">
+<style>
+  .autovac-page { padding: 1.5rem; }
+  .autovac-table-scroll {
+    overflow-x: auto;
+    overflow-y: hidden;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: .75rem;
+    margin-bottom: 1rem;
+    scrollbar-width: thin;
+    scrollbar-color: #94a3b8 #f1f5f9;
+  }
+  .autovac-table-scroll::-webkit-scrollbar { height: 10px; }
+  .autovac-table-scroll::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 999px; }
+  .autovac-table-scroll::-webkit-scrollbar-thumb { background: #94a3b8; border-radius: 999px; }
+  .autovac-table {
+    min-width: 1800px;
+    margin-bottom: 0;
+  }
+  .autovac-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+  }
+  .autovac-table th.sortable .sort-indicator {
+    font-size: .7rem;
+    color: #94a3b8;
+    margin-left: .2rem;
+  }
+  .autovac-table th.sortable.active .sort-indicator {
+    color: #2563eb;
+  }
+  .autovac-table .autovac-col-filter {
+    min-width: 88px;
+    font-size: .72rem;
+    padding: .2rem .35rem;
+  }
+  .autovac-table thead tr.autovac-filter-row th {
+    background: #fff;
+    border-top: 0;
+    padding-top: 0;
+    vertical-align: top;
+  }
+  .autovac-table th,
+  .autovac-table td {
+    white-space: nowrap;
+    vertical-align: middle;
+  }
+  .autovac-table .autovac-note {
+    white-space: normal;
+    min-width: 220px;
+    max-width: 320px;
+  }
+  .autovac-actions {
+    min-width: 280px;
+  }
+  .autovac-actions .btn { white-space: nowrap; }
+  .autovac-risk-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    font-size: .84rem;
+  }
+  .autovac-risk-list li + li { margin-top: .35rem; }
+  .autovac-exec-result {
+    border-radius: .75rem;
+    padding: .75rem .9rem;
+    font-size: .82rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .autovac-snippet {
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: .75rem;
+    padding: .75rem .9rem;
+    font-size: .78rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+  }
+  .pagination-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    margin-top: .5rem;
+  }
+  .pagination-info { color: #64748b; font-size: .875rem; }
+  .pagination-controls { display: flex; flex-wrap: wrap; gap: .35rem; }
+  .criteria-help-toggle { cursor: pointer; }
+  .criteria-help-body { font-size: .875rem; color: #475569; }
+  .criteria-help-body ul { margin-bottom: .75rem; padding-left: 1.25rem; }
+  .criteria-help-body li { margin-bottom: .35rem; }
+  .autovac-calc-btn {
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    line-height: 1;
+    font-size: .75rem;
+    font-weight: 700;
+    border-radius: 999px;
+  }
+  .autovac-calc-section + .autovac-calc-section {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e2e8f0;
+  }
+  .autovac-calc-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    font-size: .875rem;
+  }
+  .autovac-calc-list li + li { margin-top: .3rem; }
+  .autovac-calc-params {
+    font-size: .875rem;
+    margin: 0;
+  }
+  .autovac-calc-params dt { font-weight: 600; }
+  .autovac-calc-formula {
+    font-size: .84rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: .5rem;
+    padding: .5rem .65rem;
+    margin-bottom: .35rem;
+  }
+</style>
+{% endblock stylesheets %}
+
+{% block content %}
+<div class="container-fluid autovac-page">
+  <div class="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
+    <div>
+      <h1 class="h4 mb-1">Table autovacuum tuning</h1>
+      <p class="text-muted mb-0">
+        Per-table and global autovacuum recommendations from <code>advisor_enriched.yml</code>
+        (<code>table_autovacuum_maintenance_flagged</code>, <code>table_autovacuum_cluster_load</code>).
+        {% if multi_db_filter %}<span class="ms-1">· Database <strong>{{ active_db }}</strong></span>{% endif %}
+      </p>
+    </div>
+    <div class="d-flex align-items-center flex-wrap gap-2">
+      {% if multi_db_filter %}{% include "includes/multi_db_filter.html" %}{% endif %}
+    </div>
+  </div>
+
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-body">
+      <form method="POST" action="/table_autovacuum_tune.html" class="row g-3 align-items-end">
+        {% if multi_db_filter %}<input type="hidden" name="db" value="{{ active_db }}">{% endif %}
+        <div class="col-12 col-md-4">
+          <label for="stale_days" class="form-label">Stale statistics threshold (days)</label>
+          <input class="form-control" id="stale_days" name="stale_days" type="number" min="1" max="365"
+                 value="{{ stale_days }}">
+          <div class="form-text">
+            Default: 7 days. ANALYZE is flagged when manual or auto statistics are missing or older than this.
+            VACUUM is flagged only when dead tuple pressure is significant, not from an old vacuum date alone.
+          </div>
+        </div>
+        <div class="col-12 col-md-3">
+          <button type="submit" class="btn btn-primary">Analyze tables</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  {% if criteria_help %}
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-body py-3">
+      <button class="btn btn-link p-0 text-decoration-none criteria-help-toggle d-flex align-items-center gap-2"
+              type="button" data-bs-toggle="collapse" data-bs-target="#autovac-criteria-help"
+              aria-expanded="false" aria-controls="autovac-criteria-help">
+        <span class="fw-semibold text-body">Criteria &amp; algorithms</span>
+        <span class="small text-muted">(threshold {{ criteria_help.stale_days }} day(s))</span>
+      </button>
+      <div class="collapse mt-3" id="autovac-criteria-help">
+        <div class="criteria-help-body">
+          {% for section in criteria_help.sections %}
+          <h3 class="h6 text-body mb-2">{{ section.title }}</h3>
+          <ul>
+            {% for item in section.points %}
+            <li>{{ item }}</li>
+            {% endfor %}
+          </ul>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if advisor_result and not advisor_result.ok %}
+  <div class="alert alert-warning">{{ advisor_result.error }}</div>
+  {% elif advisor_result and advisor_result.ok %}
+  {% set global_tuning = advisor_result.global_tuning %}
+  {% if global_tuning and global_tuning.ok %}
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-body">
+      <div class="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-3">
+        <div>
+          <h2 class="h5 mb-1">Global autovacuum tuning</h2>
+          <p class="text-muted small mb-0">
+            Cluster-wide <code>ALTER SYSTEM</code> proposals based on dead tuple pressure, flagged tables,
+            and active autovacuum workers.
+          </p>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+          {% if global_tuning.load_level == 'critical' %}
+          <span class="badge bg-danger">{{ global_tuning.load_label }}</span>
+          {% elif global_tuning.load_level == 'high' %}
+          <span class="badge bg-warning text-dark">{{ global_tuning.load_label }}</span>
+          {% elif global_tuning.load_level == 'medium' %}
+          <span class="badge bg-info text-dark">{{ global_tuning.load_label }}</span>
+          {% else %}
+          <span class="badge bg-success-subtle text-success">{{ global_tuning.load_label }}</span>
+          {% endif %}
+          {% if global_tuning.recommendations %}
+          <button type="button" class="btn btn-outline-primary btn-sm" id="autovac-global-copy">Copy all</button>
+          <button type="button" class="btn btn-warning btn-sm" id="autovac-global-run-all">Run all + reload</button>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="row g-3 mb-4">
+        <div class="col-md-3"><div class="border rounded p-3 h-100"><div class="small text-muted">Dead tuples (cluster)</div><div class="h5 mb-0">{{ global_tuning.metrics.total_dead_tuples }}</div></div></div>
+        <div class="col-md-3"><div class="border rounded p-3 h-100"><div class="small text-muted">High dead pressure tables</div><div class="h5 mb-0">{{ global_tuning.metrics.high_dead_pressure_tables }}</div></div></div>
+        <div class="col-md-3"><div class="border rounded p-3 h-100"><div class="small text-muted">Autovacuum workers</div><div class="h5 mb-0">{{ global_tuning.metrics.active_autovacuum_workers }} / {{ global_tuning.current_settings.autovacuum_max_workers or '—' }}</div></div></div>
+        <div class="col-md-3"><div class="border rounded p-3 h-100"><div class="small text-muted">Flagged tables</div><div class="h5 mb-0">{{ global_tuning.metrics.flagged_table_count }}</div></div></div>
+      </div>
+
+      {% if global_tuning.recommendations %}
+      <div class="autovac-table-scroll mb-3">
+        <table class="table table-sm autovac-table mb-0">
+          <thead class="table-light">
+            <tr>
+              <th>Parameter</th>
+              <th>Current</th>
+              <th>Recommended</th>
+              <th>Apply</th>
+              <th>Rationale</th>
+              <th class="text-end">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in global_tuning.recommendations %}
+            <tr>
+              <td><code>{{ item.parameter }}</code></td>
+              <td>{{ item.current_value }}{% if item.unit %} {{ item.unit }}{% endif %}</td>
+              <td class="fw-semibold">{{ item.recommended_value }}{% if item.unit %} {{ item.unit }}{% endif %}</td>
+              <td>
+                {% if item.context == 'postmaster' %}
+                <span class="badge bg-warning-subtle text-warning">Restart</span>
+                {% else %}
+                <span class="badge bg-success-subtle text-success">Reload</span>
+                {% endif %}
+              </td>
+              <td class="autovac-note small text-muted">{{ item.rationale }}</td>
+              <td class="text-end">
+                <div class="d-inline-flex flex-wrap gap-1 justify-content-end">
+                  <button type="button" class="btn btn-outline-secondary btn-sm autovac-global-copy-one"
+                          data-sql="{{ item.sql | e }}">Copy</button>
+                  <button type="button" class="btn btn-warning btn-sm autovac-global-run-one"
+                          data-global-index="{{ loop.index0 }}">Run</button>
+                </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <pre class="autovac-snippet d-none" id="autovac-global-script">{{ global_tuning.script_sql }}</pre>
+      {% if global_tuning.restart_required %}
+      <div class="alert alert-warning small mb-0">
+        <code>autovacuum_max_workers</code> requires a PostgreSQL restart. Other parameters can use
+        <code>SELECT pg_reload_conf();</code> after <code>ALTER SYSTEM</code>.
+      </div>
+      {% else %}
+      <div class="alert alert-info small mb-0">
+        Review workload and I/O capacity before applying. Reload with <code>SELECT pg_reload_conf();</code>
+        after applying the <code>ALTER SYSTEM</code> commands.
+      </div>
+      {% endif %}
+      {% else %}
+      <div class="alert alert-success small mb-0">
+        {{ global_tuning.summary }} No global parameter change is recommended right now.
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {% if advisor_result.tables %}
+  <div class="row g-3 mb-4">
+    <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Tables flagged</div><div class="h4 mb-0">{{ advisor_result.summary.total }}</div></div></div></div>
+    <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Analyze issues</div><div class="h4 mb-0">{{ advisor_result.summary.never_analyzed + advisor_result.summary.stale_analyze }}</div><div class="small text-muted">{{ advisor_result.summary.never_analyzed }} never · {{ advisor_result.summary.stale_analyze }} stale</div></div></div></div>
+    <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Vacuum issues</div><div class="h4 mb-0">{{ advisor_result.summary.never_vacuumed + advisor_result.summary.stale_vacuum }}</div><div class="small text-muted">{{ advisor_result.summary.never_vacuumed }} never · {{ advisor_result.summary.stale_vacuum }} stale</div></div></div></div>
+    <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Threshold</div><div class="h4 mb-0">{{ stale_days }} d</div><div class="small text-muted">Analyze age · vacuum + dead pressure</div></div></div></div>
+  </div>
+
+  <div class="card border-0 shadow-sm mb-3">
+    <div class="card-body py-3">
+      <div class="d-flex flex-wrap align-items-center gap-2">
+        <span class="small text-muted me-1">Run all flagged tables ({{ advisor_result.summary.total }}):</span>
+        <button type="button" class="btn btn-warning btn-sm" id="autovac-batch-vacuum">Run all VACUUM</button>
+        <button type="button" class="btn btn-success btn-sm" id="autovac-batch-analyze">Run all ANALYZE</button>
+        <button type="button" class="btn btn-primary btn-sm" id="autovac-batch-alter"
+                {% if not advisor_result.batch_actions.alter_eligible_count %}disabled{% endif %}>
+          Run all ALTER{% if advisor_result.batch_actions.alter_eligible_count < advisor_result.summary.total %}
+          ({{ advisor_result.batch_actions.alter_eligible_count }}){% endif %}
+        </button>
+        <button type="button" class="btn btn-danger btn-sm" id="autovac-batch-all">Run all (VACUUM → ANALYZE → ALTER)</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+    <div class="d-flex align-items-center flex-wrap gap-2">
+      <label for="autovac-per-page" class="form-label mb-0 small text-muted">Rows per page</label>
+      <select id="autovac-per-page" class="form-select form-select-sm" style="width: auto;">
+        <option value="10">10</option>
+        <option value="25" selected>25</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+      </select>
+      <button type="button" class="btn btn-outline-secondary btn-sm" id="autovac-reset-filters">Reset filters</button>
+      <span class="small text-muted" id="autovac-visible-count"></span>
+    </div>
+    <div class="small text-muted">Click column headers to sort · filter in the row below headers</div>
+  </div>
+
+  <div class="autovac-table-scroll">
+    <table class="table table-sm autovac-table align-middle">
+      <thead class="table-light">
+        <tr id="autovac-header-row">
+          <th class="sortable" data-sort-key="object_name">Table <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="issue">Issue <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="last_analyze">Last analyze <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="last_autoanalyze">Last autoanalyze <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="stats_age_days">Stats age <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="last_vacuum">Last vacuum <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="last_autovacuum">Last autovacuum <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="vacuum_age_days">Vacuum age <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="n_live_tup">Rows <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="n_dead_tup">Dead tuples <span class="sort-indicator"></span></th>
+          <th class="sortable" data-sort-key="vacuum_urgency">Vacuum urgency <span class="sort-indicator"></span></th>
+          <th class="text-end autovac-actions">Commands</th>
+        </tr>
+        <tr class="autovac-filter-row">
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="object_name" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="issue" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_analyze" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autoanalyze" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="stats_age_days" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_vacuum" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autovacuum" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_age_days" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_live_tup" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_dead_tup" placeholder="Filter"></th>
+          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_urgency" placeholder="Filter"></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="autovac-table-body"></tbody>
+    </table>
+  </div>
+
+  <div id="autovac-empty-filter" class="alert alert-light border d-none mb-3">
+    No table matches the current column filters.
+  </div>
+
+  <div id="autovac-pagination" class="pagination-wrapper">
+    <div id="autovac-pagination-info" class="pagination-info"></div>
+    <div id="autovac-pagination-controls" class="pagination-controls"></div>
+  </div>
+  {% elif advisor_result.tables is defined and not advisor_result.tables %}
+  <div class="alert alert-info mb-0">
+    No tables require maintenance for the current criteria
+    (fresh analyze within {{ stale_days }} day(s), or no significant dead tuple pressure for vacuum).
+  </div>
+  {% endif %}
+  {% endif %}
+</div>
+
+{% if advisor_result and advisor_result.ok and advisor_result.tables %}
+<script type="application/json" id="autovac-rows-json">{{ advisor_result.tables | tojson }}</script>
+<script type="application/json" id="autovac-batch-json">{{ advisor_result.batch_actions | tojson }}</script>
+{% endif %}
+
+{% if advisor_result and advisor_result.ok and advisor_result.global_tuning and advisor_result.global_tuning.recommendations %}
+<script type="application/json" id="autovac-global-json">{{ advisor_result.global_tuning.recommendations | tojson }}</script>
+{% endif %}
+
+<div class="modal fade" id="autovacCalcModal" tabindex="-1" aria-labelledby="autovacCalcModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="h5 modal-title" id="autovacCalcModalLabel">Table calculation details</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="autovac-calc-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="autovacExecModal" tabindex="-1" aria-labelledby="autovacExecModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="h5 modal-title" id="autovacExecModalLabel">Run maintenance command</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <dl class="row small mb-3">
+          <dt class="col-sm-3">Target</dt>
+          <dd class="col-sm-9" id="autovac-exec-target"></dd>
+          <dt class="col-sm-3">Action</dt>
+          <dd class="col-sm-9" id="autovac-exec-action"></dd>
+        </dl>
+        <p class="small text-muted mb-2" id="autovac-exec-rationale"></p>
+
+        <div class="alert alert-warning py-2 px-3 mb-3">
+          <div class="fw-semibold small mb-2">Risks and operational impact</div>
+          <ul class="autovac-risk-list" id="autovac-exec-risks"></ul>
+        </div>
+
+        <div class="mb-2 fw-semibold small">SQL to execute</div>
+        <pre class="autovac-snippet" id="autovac-exec-sql"></pre>
+
+        <div class="form-check mt-3">
+          <input class="form-check-input" type="checkbox" id="autovac-exec-confirm">
+          <label class="form-check-label small" for="autovac-exec-confirm">
+            I reviewed the risks and want to run this command on the connected database.
+          </label>
+        </div>
+
+        <div id="autovac-exec-result-wrapper" class="mt-3 d-none">
+          <div class="small text-muted mb-1">Execution result</div>
+          <div id="autovac-exec-result" class="autovac-exec-result"></div>
+          <div class="small text-muted mt-2 mb-1">Execution time</div>
+          <div id="autovac-exec-time" class="fw-semibold small">Pending...</div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-outline-primary" id="autovac-exec-copy">Copy SQL</button>
+        <button type="button" class="btn btn-warning" id="autovac-exec-run" disabled>Run now</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block javascripts %}
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const rowsDataEl = document.getElementById("autovac-rows-json");
+  const globalDataEl = document.getElementById("autovac-global-json");
+  const batchDataEl = document.getElementById("autovac-batch-json");
+  const rowsData = rowsDataEl ? JSON.parse(rowsDataEl.textContent || "[]") : [];
+  const globalData = globalDataEl ? JSON.parse(globalDataEl.textContent || "[]") : [];
+  const batchData = batchDataEl ? JSON.parse(batchDataEl.textContent || "{}") : {};
+  const tableBody = document.getElementById("autovac-table-body");
+  const emptyFilter = document.getElementById("autovac-empty-filter");
+  const visibleCount = document.getElementById("autovac-visible-count");
+  const filterInputs = Array.from(document.querySelectorAll(".autovac-col-filter"));
+  const sortHeaders = Array.from(document.querySelectorAll("#autovac-header-row .sortable"));
+  const perPageSelect = document.getElementById("autovac-per-page");
+  const paginationInfo = document.getElementById("autovac-pagination-info");
+  const paginationControls = document.getElementById("autovac-pagination-controls");
+  const paginationWrapper = document.getElementById("autovac-pagination");
+  const modalEl = document.getElementById("autovacExecModal");
+  const calcModalEl = document.getElementById("autovacCalcModal");
+  const calcModalBody = document.getElementById("autovac-calc-body");
+  const calcModalTitle = document.getElementById("autovacCalcModalLabel");
+  const modalTitle = document.getElementById("autovacExecModalLabel");
+  const execTarget = document.getElementById("autovac-exec-target");
+  const execAction = document.getElementById("autovac-exec-action");
+  const execRationale = document.getElementById("autovac-exec-rationale");
+  const execRisks = document.getElementById("autovac-exec-risks");
+  const execSql = document.getElementById("autovac-exec-sql");
+  const execConfirm = document.getElementById("autovac-exec-confirm");
+  const execCopy = document.getElementById("autovac-exec-copy");
+  const execRun = document.getElementById("autovac-exec-run");
+  const execResultWrapper = document.getElementById("autovac-exec-result-wrapper");
+  const execResult = document.getElementById("autovac-exec-result");
+  const execTime = document.getElementById("autovac-exec-time");
+  let currentPage = 1;
+  let sortKey = "object_name";
+  let sortDirection = "asc";
+  let pendingExec = { sql: "", statements: [], label: "Run now" };
+
+  const issueLabels = {
+    never_analyzed: "Never analyzed",
+    stale_analyze: "Stale stats",
+    never_vacuumed: "Never vacuumed",
+    stale_vacuum: "Stale vacuum",
+  };
+
+  function formatTimestamp(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    return String(value).replace("T", " ").slice(0, 19);
+  }
+
+  function formatAge(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    return String(value) + " d";
+  }
+
+  function rowIssueText(row) {
+    const badges = (row.issue_types || []).map(function (issue) {
+      return issueLabels[issue] || issue;
+    });
+    return badges.concat(row.recommendation_note || "").join(" ");
+  }
+
+  function rowFilterText(row, key) {
+    switch (key) {
+      case "object_name":
+        return [row.object_name, row.table_size_pretty].filter(Boolean).join(" ");
+      case "issue":
+        return rowIssueText(row);
+      case "last_analyze":
+        return formatTimestamp(row.last_analyze);
+      case "last_autoanalyze":
+        return formatTimestamp(row.last_autoanalyze);
+      case "stats_age_days":
+        return formatAge(row.stats_age_days);
+      case "last_vacuum":
+        return formatTimestamp(row.last_vacuum);
+      case "last_autovacuum":
+        return formatTimestamp(row.last_autovacuum);
+      case "vacuum_age_days":
+        return formatAge(row.vacuum_age_days);
+      case "n_live_tup":
+        return String(row.n_live_tup ?? "");
+      case "n_dead_tup":
+        return String(row.n_dead_tup ?? "");
+      case "vacuum_urgency":
+        return String(row.vacuum_urgency ?? "");
+      default:
+        return "";
+    }
+  }
+
+  function rowSortValue(row, key) {
+    switch (key) {
+      case "object_name":
+        return row.object_name || "";
+      case "issue":
+        return rowIssueText(row);
+      case "last_analyze":
+      case "last_autoanalyze":
+      case "last_vacuum":
+      case "last_autovacuum":
+        return row[key] ? Date.parse(String(row[key]).replace(" ", "T")) : null;
+      case "stats_age_days":
+      case "vacuum_age_days":
+      case "n_live_tup":
+      case "n_dead_tup":
+      case "vacuum_urgency":
+        return row[key] === null || row[key] === undefined || row[key] === "" ? null : Number(row[key]);
+      default:
+        return null;
+    }
+  }
+
+  function getActiveFilters() {
+    const filters = {};
+    filterInputs.forEach(function (input) {
+      const value = (input.value || "").trim().toLowerCase();
+      if (value) filters[input.dataset.filterKey] = value;
+    });
+    return filters;
+  }
+
+  function getFilteredRows() {
+    const filters = getActiveFilters();
+    return rowsData
+      .map(function (row, index) { return { row: row, index: index }; })
+      .filter(function (entry) {
+        return Object.keys(filters).every(function (key) {
+          return rowFilterText(entry.row, key).toLowerCase().includes(filters[key]);
+        });
+      });
+  }
+
+  function getFilteredSortedRows() {
+    const filtered = getFilteredRows().slice();
+    filtered.sort(function (a, b) {
+      const left = rowSortValue(a.row, sortKey);
+      const right = rowSortValue(b.row, sortKey);
+      if (left === null && right === null) return a.index - b.index;
+      if (left === null) return 1;
+      if (right === null) return -1;
+      if (left < right) return sortDirection === "asc" ? -1 : 1;
+      if (left > right) return sortDirection === "asc" ? 1 : -1;
+      return a.index - b.index;
+    });
+    return filtered;
+  }
+
+  function renderIssueCell(row) {
+    const badges = (row.issue_types || []).map(function (issue) {
+      if (issue === "never_analyzed") return '<span class="badge bg-danger-subtle text-danger me-1">Never analyzed</span>';
+      if (issue === "stale_analyze") return '<span class="badge bg-warning-subtle text-warning me-1">Stale stats</span>';
+      if (issue === "never_vacuumed") return '<span class="badge bg-danger-subtle text-danger me-1">Never vacuumed</span>';
+      if (issue === "stale_vacuum") return '<span class="badge bg-warning-subtle text-warning me-1">Stale vacuum</span>';
+      return "";
+    }).join("");
+    return badges + '<div class="small text-muted mt-1">' + escapeHtml(row.recommendation_note || "") + "</div>";
+  }
+
+  function renderListItems(items) {
+    if (!items || !items.length) return '<p class="small text-muted mb-0">—</p>';
+    return '<ul class="autovac-calc-list">' + items.map(function (item) {
+      return "<li>" + escapeHtml(item) + "</li>";
+    }).join("") + "</ul>";
+  }
+
+  function renderCalculationHelp(help) {
+    if (!help) return '<p class="text-muted mb-0">No calculation details available.</p>';
+
+    let html = '<div class="autovac-calc-section">'
+      + '<div class="fw-semibold mb-2">Why this table is flagged</div>'
+      + renderListItems(help.flagging || [])
+      + '</div>';
+
+    html += '<div class="autovac-calc-section">'
+      + '<div class="fw-semibold mb-2">Metrics used</div>'
+      + renderListItems(help.metrics || [])
+      + '</div>';
+
+    if (help.recommendation_note) {
+      html += '<div class="autovac-calc-section">'
+        + '<div class="fw-semibold mb-2">Summary note</div>'
+        + '<p class="small mb-0">' + escapeHtml(help.recommendation_note) + '</p>'
+        + '</div>';
+    }
+
+    const alter = help.alter || {};
+    html += '<div class="autovac-calc-section">'
+      + '<div class="fw-semibold mb-2">ALTER TABLE autovacuum proposal</div>';
+
+    if (!alter.available && !alter.preview_only) {
+      html += '<p class="small text-muted mb-0">' + escapeHtml(alter.skip_reason || "Not available.") + '</p>';
+    } else {
+      if (alter.preview_only && alter.skip_reason) {
+        html += '<p class="small text-warning mb-2">' + escapeHtml(alter.skip_reason) + '</p>';
+        html += '<p class="small text-muted mb-2">Preview of proposed settings after ANALYZE:</p>';
+      }
+      const params = alter.parameters || {};
+      html += '<dl class="row autovac-calc-params mb-2">'
+        + '<dt class="col-sm-6">autovacuum_analyze_scale_factor</dt><dd class="col-sm-6">' + escapeHtml(params.autovacuum_analyze_scale_factor) + '</dd>'
+        + '<dt class="col-sm-6">autovacuum_analyze_threshold</dt><dd class="col-sm-6">' + escapeHtml(params.autovacuum_analyze_threshold) + '</dd>'
+        + '<dt class="col-sm-6">autovacuum_vacuum_scale_factor</dt><dd class="col-sm-6">' + escapeHtml(params.autovacuum_vacuum_scale_factor) + '</dd>'
+        + '<dt class="col-sm-6">autovacuum_vacuum_threshold</dt><dd class="col-sm-6">' + escapeHtml(params.autovacuum_vacuum_threshold) + '</dd>'
+        + '</dl>';
+      html += '<div class="fw-semibold small mb-1">Rules applied</div>' + renderListItems(alter.adjustments || []);
+      if (alter.vacuum_formula) {
+        html += '<div class="autovac-calc-formula"><strong>Vacuum trigger:</strong> ' + escapeHtml(alter.vacuum_formula) + '</div>';
+      }
+      if (alter.analyze_formula) {
+        html += '<div class="autovac-calc-formula"><strong>Analyze trigger:</strong> ' + escapeHtml(alter.analyze_formula) + '</div>';
+      }
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function openCalculationModal(row) {
+    if (!calcModalEl || !calcModalBody) return;
+    if (calcModalTitle) {
+      calcModalTitle.textContent = "Calculation: " + (row.object_name || "table");
+    }
+    calcModalBody.innerHTML = renderCalculationHelp(row.calculation_help || {});
+    if (window.bootstrap && window.bootstrap.Modal) {
+      window.bootstrap.Modal.getOrCreateInstance(calcModalEl).show();
+    }
+  }
+
+  function bindCalculationButtons() {
+    document.querySelectorAll(".autovac-calc-btn").forEach(function (button) {
+      button.addEventListener("click", function () {
+        const index = Number(button.dataset.rowIndex);
+        const entry = rowsData[index];
+        if (entry) openCalculationModal(entry);
+      });
+    });
+  }
+
+  function renderCommandsCell(row, index) {
+    const alterHtml = row.alter_available
+      ? '<button type="button" class="btn btn-outline-primary btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="alter">Alter</button>'
+      : '<span class="small text-muted ms-1" title="' + escapeHtml(row.alter_skip_reason || "") + '">Alter N/A</span>';
+    return '<button type="button" class="btn btn-outline-success btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="analyze">Analyze</button>'
+      + '<button type="button" class="btn btn-outline-warning btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="vacuum">Vacuum</button>'
+      + alterHtml;
+  }
+
+  function bindCommandButtons() {
+    document.querySelectorAll(".autovac-cmd-btn").forEach(function (button) {
+      button.addEventListener("click", function () {
+        openTableCommandModal(button);
+      });
+    });
+  }
+
+  function updateSortIndicators() {
+    sortHeaders.forEach(function (header) {
+      const indicator = header.querySelector(".sort-indicator");
+      const active = header.dataset.sortKey === sortKey;
+      header.classList.toggle("active", active);
+      if (indicator) {
+        indicator.textContent = active ? (sortDirection === "asc" ? "▲" : "▼") : "↕";
+      }
+    });
+  }
+
+  function renderTable() {
+    if (!tableBody) return;
+    const filtered = getFilteredSortedRows();
+    const size = pageSize();
+    const totalPages = Math.max(1, Math.ceil(filtered.length / size));
+    if (currentPage > totalPages) currentPage = totalPages;
+
+    const start = (currentPage - 1) * size;
+    const end = Math.min(start + size, filtered.length);
+    const pageRows = filtered.slice(start, end);
+
+    if (visibleCount) {
+      visibleCount.textContent = filtered.length + " / " + rowsData.length + " tables";
+    }
+
+    if (!filtered.length) {
+      tableBody.innerHTML = "";
+      emptyFilter?.classList.remove("d-none");
+      if (paginationInfo) paginationInfo.textContent = "0 tables";
+      paginationWrapper?.classList.add("d-none");
+      updateSortIndicators();
+      return;
+    }
+
+    emptyFilter?.classList.add("d-none");
+    tableBody.innerHTML = pageRows.map(function (entry) {
+      const row = entry.row;
+      const index = entry.index;
+      return '<tr class="autovac-data-row">'
+        + '<td><div class="d-flex align-items-start gap-2">'
+        + '<button type="button" class="btn btn-outline-secondary btn-sm autovac-calc-btn flex-shrink-0" '
+        + 'data-row-index="' + index + '" title="Show flagging and ALTER calculation" aria-label="Show calculation details">?</button>'
+        + '<div><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
+        + '<div class="small text-muted">' + escapeHtml(row.table_size_pretty || "—") + '</div></div></div></td>'
+        + '<td class="autovac-note">' + renderIssueCell(row) + '</td>'
+        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_analyze)) + '</td>'
+        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_autoanalyze)) + '</td>'
+        + '<td>' + escapeHtml(formatAge(row.stats_age_days)) + '</td>'
+        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_vacuum)) + '</td>'
+        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_autovacuum)) + '</td>'
+        + '<td>' + escapeHtml(formatAge(row.vacuum_age_days)) + '</td>'
+        + '<td>' + escapeHtml(String(row.n_live_tup || 0)) + '</td>'
+        + '<td>' + escapeHtml(String(row.n_dead_tup || 0)) + '</td>'
+        + '<td>' + escapeHtml(String(row.vacuum_urgency ?? "—")) + '</td>'
+        + '<td class="text-end autovac-actions">' + renderCommandsCell(row, index) + '</td>'
+        + '</tr>';
+    }).join("");
+
+    bindCommandButtons();
+    bindCalculationButtons();
+    updateSortIndicators();
+
+    if (paginationInfo) {
+      paginationInfo.textContent = "Showing " + (start + 1) + "-" + end + " of " + filtered.length + " tables";
+    }
+    drawPaginationControls(totalPages);
+  }
+
+  const cmdLabels = {
+    analyze: "ANALYZE",
+    vacuum: "VACUUM",
+    alter: "ALTER TABLE (autovacuum tuning)",
+    alter_system: "ALTER SYSTEM",
+    alter_system_batch: "ALTER SYSTEM (batch) + reload",
+    batch_vacuum: "Batch VACUUM",
+    batch_analyze: "Batch ANALYZE",
+    batch_alter: "Batch ALTER TABLE",
+    batch_all: "Batch VACUUM + ANALYZE + ALTER",
+  };
+
+  function escapeHtml(value) {
+    const div = document.createElement("div");
+    div.textContent = value == null ? "" : String(value);
+    return div.innerHTML;
+  }
+
+  function splitSqlStatements(sql) {
+    return String(sql || "")
+      .split(";")
+      .map(function (chunk) { return chunk.trim(); })
+      .filter(function (chunk) {
+        if (!chunk) return false;
+        return !chunk.split("\n").every(function (line) {
+          const trimmed = line.trim();
+          return !trimmed || trimmed.startsWith("--");
+        });
+      })
+      .map(function (chunk) { return chunk + ";"; });
+  }
+
+  function normalizeStatement(sql) {
+    const text = String(sql || "").trim();
+    if (!text) return "";
+    return text.endsWith(";") ? text : text + ";";
+  }
+
+  function appendBatchStatements(statements, entries, field, onlyAlterEligible) {
+    entries.forEach(function (entry) {
+      const row = entry.row;
+      if (onlyAlterEligible && !row.alter_available) return;
+      const sql = normalizeStatement(row[field]);
+      if (sql) statements.push(sql);
+    });
+  }
+
+  function openTableBatchModal(kind) {
+    const statements = [];
+    const batchKey = kind === "all" ? "all" : kind;
+    const risks = ((batchData[batchKey] && batchData[batchKey].risks) || []).slice();
+    const filteredEntries = getFilteredRows();
+
+    if (kind === "vacuum" || kind === "all") {
+      appendBatchStatements(statements, filteredEntries, "vacuum_sql", false);
+    }
+    if (kind === "analyze" || kind === "all") {
+      appendBatchStatements(statements, filteredEntries, "analyze_sql", false);
+    }
+    if (kind === "alter" || kind === "all") {
+      appendBatchStatements(statements, filteredEntries, "autovacuum_sql", true);
+    }
+
+    const alterEligibleInView = filteredEntries.filter(function (entry) {
+      return entry.row.alter_available;
+    }).length;
+
+    if ((kind === "alter" || kind === "all") && alterEligibleInView === 0) {
+      window.alert("No ALTER TABLE tuning is available in the current view.");
+      return;
+    }
+
+    if (kind === "all" && alterEligibleInView < filteredEntries.length) {
+      risks.push(
+        "ALTER TABLE is skipped for tables that have never been analyzed; run ANALYZE on them first."
+      );
+    }
+
+    if (filteredEntries.length < rowsData.length) {
+      risks.push("Batch run applies to the currently filtered table set only.");
+    }
+
+    const actionKey = kind === "all" ? "batch_all" : "batch_" + kind;
+    const rationales = {
+      vacuum: "Reclaim dead tuples on all flagged tables.",
+      analyze: "Refresh planner statistics on all flagged tables.",
+      alter: "Apply recommended per-table autovacuum settings on flagged tables with existing statistics.",
+      all: "Full maintenance pass: VACUUM, then ANALYZE, then ALTER TABLE tuning where statistics exist.",
+    };
+
+    if (kind === "alter" && !statements.length) {
+      window.alert("No ALTER TABLE tuning is available: all flagged tables still require ANALYZE.");
+      return;
+    }
+
+    openExecModal({
+      title: "Run all " + (cmdLabels[actionKey] || kind),
+      target: filteredEntries.length + " table(s) in current view",
+      action: cmdLabels[actionKey] || kind,
+      rationale: rationales[kind] || "",
+      risks: risks,
+      sql: statements.join("\n\n"),
+      statements: statements,
+      runLabel: "Run batch (" + statements.length + ")",
+    });
+  }
+
+  function pageSize() {
+    return Number(perPageSelect?.value || 25);
+  }
+
+  function pageButton(label, page, active, disabled) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "btn btn-sm " + (active ? "btn-primary" : "btn-outline-primary");
+    button.textContent = label;
+    button.disabled = disabled;
+    if (!disabled) {
+      button.addEventListener("click", function () {
+        currentPage = page;
+        renderTable();
+        document.querySelector(".autovac-table-scroll")?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      });
+    }
+    return button;
+  }
+
+  function drawPaginationControls(totalPages) {
+    if (!paginationControls || !paginationWrapper) return;
+    paginationControls.innerHTML = "";
+    if (totalPages <= 1) {
+      paginationWrapper.classList.add("d-none");
+      return;
+    }
+    paginationWrapper.classList.remove("d-none");
+    paginationControls.appendChild(pageButton("Previous", currentPage - 1, false, currentPage <= 1));
+    for (let page = 1; page <= totalPages; page += 1) {
+      if (page === 1 || page === totalPages || Math.abs(page - currentPage) <= 2) {
+        paginationControls.appendChild(pageButton(String(page), page, page === currentPage, false));
+      } else if (page === currentPage - 3 || page === currentPage + 3) {
+        const ellipsis = document.createElement("span");
+        ellipsis.className = "btn btn-sm btn-light disabled";
+        ellipsis.textContent = "…";
+        paginationControls.appendChild(ellipsis);
+      }
+    }
+    paginationControls.appendChild(pageButton("Next", currentPage + 1, false, currentPage >= totalPages));
+  }
+
+  function copyText(text, button) {
+    if (!text) return;
+    navigator.clipboard.writeText(text).then(function () {
+      if (!button) return;
+      const original = button.textContent;
+      button.textContent = "Copied";
+      setTimeout(function () { button.textContent = original; }, 1200);
+    });
+  }
+
+  function renderRiskList(risks) {
+    if (!execRisks) return;
+    execRisks.innerHTML = "";
+    (risks || []).forEach(function (risk) {
+      const item = document.createElement("li");
+      item.textContent = risk;
+      execRisks.appendChild(item);
+    });
+  }
+
+  function resetExecModalState() {
+    if (execConfirm) execConfirm.checked = false;
+    if (execRun) execRun.disabled = true;
+    execResultWrapper?.classList.add("d-none");
+    if (execResult) execResult.textContent = "";
+    if (execTime) execTime.textContent = "Pending...";
+  }
+
+  function openExecModal(config) {
+    pendingExec = {
+      sql: config.sql || "",
+      statements: config.statements || splitSqlStatements(config.sql),
+      label: config.runLabel || "Run now",
+    };
+
+    if (modalTitle) modalTitle.textContent = config.title || "Run maintenance command";
+    if (execTarget) execTarget.textContent = config.target || "—";
+    if (execAction) execAction.textContent = config.action || "—";
+    if (execRationale) execRationale.textContent = config.rationale || "";
+    renderRiskList(config.risks || []);
+    if (execSql) execSql.textContent = config.sql || "";
+    if (execRun) execRun.textContent = pendingExec.label;
+
+    resetExecModalState();
+
+    if (modalEl && window.bootstrap) {
+      window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+  }
+
+  function openTableCommandModal(button) {
+    const rowIndex = Number(button.dataset.rowIndex);
+    const cmd = button.dataset.cmd || "";
+    const row = rowsData[rowIndex] || {};
+    const sqlByCmd = {
+      analyze: row.analyze_sql || "",
+      vacuum: row.vacuum_sql || "",
+      alter: row.autovacuum_sql || "",
+    };
+    const rationaleByCmd = {
+      analyze: "Refresh planner statistics for " + (row.object_name || "this table") + ".",
+      vacuum: "Reclaim dead tuples (" + (row.n_dead_tup || 0) + " dead) on "
+        + (row.object_name || "this table") + ".",
+      alter: row.tuning_rationale || "",
+    };
+    const risksByCmd = {
+      analyze: row.analyze_risks || [],
+      vacuum: row.vacuum_risks || [],
+      alter: row.alter_risks || [],
+    };
+
+    openExecModal({
+      title: "Run " + (cmdLabels[cmd] || cmd),
+      target: row.object_name || "Table",
+      action: cmdLabels[cmd] || cmd,
+      rationale: rationaleByCmd[cmd] || "",
+      risks: risksByCmd[cmd] || [],
+      sql: sqlByCmd[cmd] || "",
+      runLabel: "Run " + (cmdLabels[cmd] || cmd),
+    });
+  }
+
+  function openGlobalCommandModal(index) {
+    const item = globalData[index] || {};
+    const statements = splitSqlStatements(item.sql);
+    const risks = (item.risks || []).slice();
+    if (item.context !== "postmaster") {
+      statements.push("SELECT pg_reload_conf();");
+      risks.push("Reloads PostgreSQL configuration after ALTER SYSTEM.");
+    }
+
+    openExecModal({
+      title: "Run global autovacuum change",
+      target: item.parameter || "Cluster",
+      action: cmdLabels.alter_system,
+      rationale: item.rationale || "",
+      risks: risks,
+      sql: statements.join("\n"),
+      statements: statements,
+      runLabel: "Run ALTER SYSTEM",
+    });
+  }
+
+  function openGlobalBatchModal() {
+    const statements = [];
+    const risks = [];
+    globalData.forEach(function (item) {
+      splitSqlStatements(item.sql).forEach(function (sql) { statements.push(sql); });
+      (item.risks || []).forEach(function (risk) {
+        if (!risks.includes(risk)) risks.push(risk);
+      });
+    });
+    statements.push("SELECT pg_reload_conf();");
+    risks.push("Reloads configuration after all ALTER SYSTEM commands.");
+
+    openExecModal({
+      title: "Run all global autovacuum changes",
+      target: "PostgreSQL cluster",
+      action: cmdLabels.alter_system_batch,
+      rationale: "Apply all recommended global autovacuum parameters, then reload configuration.",
+      risks: risks,
+      sql: statements.join("\n"),
+      statements: statements,
+      runLabel: "Run all + reload",
+    });
+  }
+
+  async function executeStatement(sql) {
+    const response = await fetch("/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: sql }),
+    });
+
+    let result;
+    try {
+      result = await response.json();
+    } catch (error) {
+      throw new Error("Invalid server response (" + response.status + ").");
+    }
+
+    if (!response.ok || !result.success) {
+      throw new Error(result.error || "Execution failed.");
+    }
+
+    return result.message || "OK";
+  }
+
+  async function executePendingStatements() {
+    const statements = pendingExec.statements.length
+      ? pendingExec.statements
+      : splitSqlStatements(pendingExec.sql);
+
+    if (!statements.length) {
+      throw new Error("No SQL statement to execute.");
+    }
+
+    const originalLabel = execRun?.textContent || "Run now";
+    if (execRun) {
+      execRun.disabled = true;
+      execRun.textContent = "Running...";
+    }
+
+    execResultWrapper?.classList.remove("d-none");
+    if (execResult) execResult.textContent = "Running...";
+    if (execTime) execTime.textContent = "Running...";
+
+    const startedAt = performance.now();
+    const logs = [];
+
+    try {
+      for (let index = 0; index < statements.length; index += 1) {
+        const sql = statements[index];
+        logs.push("[" + (index + 1) + "/" + statements.length + "] " + sql);
+        const message = await executeStatement(sql);
+        logs.push("Success: " + message);
+      }
+
+      const elapsedMs = Math.round(performance.now() - startedAt);
+      if (execTime) execTime.textContent = elapsedMs + " ms";
+      if (execResult) {
+        execResult.innerHTML = '<div class="text-success fw-semibold">Success</div><div class="mt-2">'
+          + escapeHtml(logs.join("\n")) + "</div>";
+      }
+    } catch (error) {
+      const elapsedMs = Math.round(performance.now() - startedAt);
+      if (execTime) execTime.textContent = elapsedMs + " ms";
+      if (execResult) {
+        execResult.innerHTML = '<div class="text-danger fw-semibold">Error</div><div class="mt-2">'
+          + escapeHtml(logs.join("\n")) + (logs.length ? "\n" : "")
+          + escapeHtml(error.message) + "</div>";
+      }
+    } finally {
+      if (execRun) {
+        execRun.textContent = originalLabel;
+        execRun.disabled = !(execConfirm && execConfirm.checked);
+      }
+    }
+  }
+
+  sortHeaders.forEach(function (header) {
+    header.addEventListener("click", function () {
+      const key = header.dataset.sortKey;
+      if (sortKey === key) {
+        sortDirection = sortDirection === "asc" ? "desc" : "asc";
+      } else {
+        sortKey = key;
+        sortDirection = "asc";
+      }
+      currentPage = 1;
+      renderTable();
+    });
+  });
+
+  filterInputs.forEach(function (input) {
+    input.addEventListener("input", function () {
+      currentPage = 1;
+      renderTable();
+    });
+  });
+
+  document.getElementById("autovac-reset-filters")?.addEventListener("click", function () {
+    filterInputs.forEach(function (input) { input.value = ""; });
+    sortKey = "object_name";
+    sortDirection = "asc";
+    currentPage = 1;
+    renderTable();
+  });
+
+  document.querySelectorAll(".autovac-global-run-one").forEach(function (button) {
+    button.addEventListener("click", function () {
+      openGlobalCommandModal(Number(button.dataset.globalIndex));
+    });
+  });
+
+  document.getElementById("autovac-global-run-all")?.addEventListener("click", openGlobalBatchModal);
+
+  document.getElementById("autovac-batch-vacuum")?.addEventListener("click", function () {
+    openTableBatchModal("vacuum");
+  });
+  document.getElementById("autovac-batch-analyze")?.addEventListener("click", function () {
+    openTableBatchModal("analyze");
+  });
+  document.getElementById("autovac-batch-alter")?.addEventListener("click", function () {
+    openTableBatchModal("alter");
+  });
+  document.getElementById("autovac-batch-all")?.addEventListener("click", function () {
+    openTableBatchModal("all");
+  });
+
+  execConfirm?.addEventListener("change", function () {
+    if (execRun) execRun.disabled = !execConfirm.checked;
+  });
+
+  execCopy?.addEventListener("click", function () {
+    copyText(pendingExec.sql || execSql?.textContent || "", execCopy);
+  });
+
+  execRun?.addEventListener("click", function () {
+    if (!execConfirm?.checked) return;
+    executePendingStatements();
+  });
+
+  modalEl?.addEventListener("hidden.bs.modal", resetExecModalState);
+
+  const globalScript = document.getElementById("autovac-global-script");
+  document.getElementById("autovac-global-copy")?.addEventListener("click", function () {
+    copyText(globalScript?.textContent || "", document.getElementById("autovac-global-copy"));
+  });
+  document.querySelectorAll(".autovac-global-copy-one").forEach(function (button) {
+    button.addEventListener("click", function () {
+      copyText(button.dataset.sql || "", button);
+    });
+  });
+
+  perPageSelect?.addEventListener("change", function () {
+    currentPage = 1;
+    renderTable();
+  });
+
+  if (tableBody && rowsData.length) {
+    renderTable();
+  }
+});
+</script>
+{% endblock javascripts %}

--- a/apps/templates/home/table_autovacuum_tune.html
+++ b/apps/templates/home/table_autovacuum_tune.html
@@ -19,8 +19,32 @@
   .autovac-table-scroll::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 999px; }
   .autovac-table-scroll::-webkit-scrollbar-thumb { background: #94a3b8; border-radius: 999px; }
   .autovac-table {
-    min-width: 1800px;
+    min-width: 1520px;
     margin-bottom: 0;
+    font-size: .875rem;
+    color: var(--pga-text, #0f172a);
+  }
+  .autovac-table thead th {
+    font-size: .78rem;
+    font-weight: 850;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--pga-muted, #64748b);
+    background: #f8fafc !important;
+    border-bottom-color: #e8eef5;
+  }
+  .autovac-table tbody td {
+    font-size: .875rem;
+    color: #334155;
+    font-variant-numeric: tabular-nums;
+  }
+  .autovac-table tbody .fw-semibold {
+    font-weight: 850;
+    color: var(--pga-text, #0f172a);
+  }
+  .autovac-table tbody .small.text-muted {
+    font-size: .84rem;
+    color: var(--pga-muted, #64748b);
   }
   .autovac-table th.sortable {
     cursor: pointer;
@@ -56,9 +80,14 @@
     min-width: 220px;
     max-width: 320px;
   }
-  .autovac-actions {
-    min-width: 280px;
+  .autovac-actions,
+  .autovac-row-actions {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: .35rem;
+    align-items: center;
   }
+  .autovac-row-actions .btn,
   .autovac-actions .btn { white-space: nowrap; }
   .autovac-risk-list {
     margin: 0;
@@ -146,29 +175,6 @@
         {% if multi_db_filter %}<span class="ms-1">· Database <strong>{{ active_db }}</strong></span>{% endif %}
       </p>
     </div>
-    <div class="d-flex align-items-center flex-wrap gap-2">
-      {% if multi_db_filter %}{% include "includes/multi_db_filter.html" %}{% endif %}
-    </div>
-  </div>
-
-  <div class="card border-0 shadow-sm mb-4">
-    <div class="card-body">
-      <form method="POST" action="/table_autovacuum_tune.html" class="row g-3 align-items-end">
-        {% if multi_db_filter %}<input type="hidden" name="db" value="{{ active_db }}">{% endif %}
-        <div class="col-12 col-md-4">
-          <label for="stale_days" class="form-label">Stale statistics threshold (days)</label>
-          <input class="form-control" id="stale_days" name="stale_days" type="number" min="1" max="365"
-                 value="{{ stale_days }}">
-          <div class="form-text">
-            Default: 7 days. ANALYZE is flagged when manual or auto statistics are missing or older than this.
-            VACUUM is flagged only when dead tuple pressure is significant, not from an old vacuum date alone.
-          </div>
-        </div>
-        <div class="col-12 col-md-3">
-          <button type="submit" class="btn btn-primary">Analyze tables</button>
-        </div>
-      </form>
-    </div>
   </div>
 
   {% if criteria_help %}
@@ -197,6 +203,7 @@
   {% endif %}
 
   {% if advisor_result and not advisor_result.ok %}
+  {% include "includes/autovac_stale_days_form.html" %}
   <div class="alert alert-warning">{{ advisor_result.error }}</div>
   {% elif advisor_result and advisor_result.ok %}
   {% set global_tuning = advisor_result.global_tuning %}
@@ -315,10 +322,12 @@
           Run all ALTER{% if advisor_result.batch_actions.alter_eligible_count < advisor_result.summary.total %}
           ({{ advisor_result.batch_actions.alter_eligible_count }}){% endif %}
         </button>
-        <button type="button" class="btn btn-danger btn-sm" id="autovac-batch-all">Run all (VACUUM → ANALYZE → ALTER)</button>
+        <button type="button" class="btn btn-danger btn-sm" id="autovac-batch-all">Run all (ALTER → ANALYZE → VACUUM)</button>
       </div>
     </div>
   </div>
+
+  {% include "includes/autovac_stale_days_form.html" %}
 
   <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
     <div class="d-flex align-items-center flex-wrap gap-2">
@@ -350,7 +359,6 @@
           <th class="sortable" data-sort-key="n_live_tup">Rows <span class="sort-indicator"></span></th>
           <th class="sortable" data-sort-key="n_dead_tup">Dead tuples <span class="sort-indicator"></span></th>
           <th class="sortable" data-sort-key="vacuum_urgency">Vacuum urgency <span class="sort-indicator"></span></th>
-          <th class="text-end autovac-actions">Commands</th>
         </tr>
         <tr class="autovac-filter-row">
           <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="object_name" placeholder="Filter"></th>
@@ -364,7 +372,6 @@
           <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_live_tup" placeholder="Filter"></th>
           <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_dead_tup" placeholder="Filter"></th>
           <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_urgency" placeholder="Filter"></th>
-          <th></th>
         </tr>
       </thead>
       <tbody id="autovac-table-body"></tbody>
@@ -380,6 +387,7 @@
     <div id="autovac-pagination-controls" class="pagination-controls"></div>
   </div>
   {% elif advisor_result.tables is defined and not advisor_result.tables %}
+  {% include "includes/autovac_stale_days_form.html" %}
   <div class="alert alert-info mb-0">
     No tables require maintenance for the current criteria
     (fresh analyze within {{ stale_days }} day(s), or no significant dead tuple pressure for vacuum).
@@ -444,7 +452,7 @@
         </div>
 
         <div id="autovac-exec-result-wrapper" class="mt-3 d-none">
-          <div class="small text-muted mb-1">Execution result</div>
+          <div class="small text-muted mb-1">Command output</div>
           <div id="autovac-exec-result" class="autovac-exec-result"></div>
           <div class="small text-muted mt-2 mb-1">Execution time</div>
           <div id="autovac-exec-time" class="fw-semibold small">Pending...</div>
@@ -755,9 +763,10 @@ document.addEventListener("DOMContentLoaded", function () {
       const row = entry.row;
       const index = entry.index;
       return '<tr class="autovac-data-row">'
-        + '<td><div class="d-flex align-items-start gap-2">'
+        + '<td><div class="d-flex align-items-start gap-2 flex-wrap">'
         + '<button type="button" class="btn btn-outline-secondary btn-sm autovac-calc-btn flex-shrink-0" '
         + 'data-row-index="' + index + '" title="Show flagging and ALTER calculation" aria-label="Show calculation details">?</button>'
+        + '<div class="autovac-row-actions flex-shrink-0">' + renderCommandsCell(row, index) + '</div>'
         + '<div><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
         + '<div class="small text-muted">' + escapeHtml(row.table_size_pretty || "—") + '</div></div></div></td>'
         + '<td class="autovac-note">' + renderIssueCell(row) + '</td>'
@@ -770,7 +779,6 @@ document.addEventListener("DOMContentLoaded", function () {
         + '<td>' + escapeHtml(String(row.n_live_tup || 0)) + '</td>'
         + '<td>' + escapeHtml(String(row.n_dead_tup || 0)) + '</td>'
         + '<td>' + escapeHtml(String(row.vacuum_urgency ?? "—")) + '</td>'
-        + '<td class="text-end autovac-actions">' + renderCommandsCell(row, index) + '</td>'
         + '</tr>';
     }).join("");
 
@@ -793,7 +801,7 @@ document.addEventListener("DOMContentLoaded", function () {
     batch_vacuum: "Batch VACUUM",
     batch_analyze: "Batch ANALYZE",
     batch_alter: "Batch ALTER TABLE",
-    batch_all: "Batch VACUUM + ANALYZE + ALTER",
+    batch_all: "Batch ALTER + ANALYZE + VACUUM",
   };
 
   function escapeHtml(value) {
@@ -837,28 +845,28 @@ document.addEventListener("DOMContentLoaded", function () {
     const risks = ((batchData[batchKey] && batchData[batchKey].risks) || []).slice();
     const filteredEntries = getFilteredRows();
 
-    if (kind === "vacuum" || kind === "all") {
-      appendBatchStatements(statements, filteredEntries, "vacuum_sql", false);
+    if (kind === "alter" || kind === "all") {
+      appendBatchStatements(statements, filteredEntries, "autovacuum_sql", true);
     }
     if (kind === "analyze" || kind === "all") {
       appendBatchStatements(statements, filteredEntries, "analyze_sql", false);
     }
-    if (kind === "alter" || kind === "all") {
-      appendBatchStatements(statements, filteredEntries, "autovacuum_sql", true);
+    if (kind === "vacuum" || kind === "all") {
+      appendBatchStatements(statements, filteredEntries, "vacuum_sql", false);
     }
 
     const alterEligibleInView = filteredEntries.filter(function (entry) {
       return entry.row.alter_available;
     }).length;
 
-    if ((kind === "alter" || kind === "all") && alterEligibleInView === 0) {
+    if (kind === "alter" && alterEligibleInView === 0) {
       window.alert("No ALTER TABLE tuning is available in the current view.");
       return;
     }
 
     if (kind === "all" && alterEligibleInView < filteredEntries.length) {
       risks.push(
-        "ALTER TABLE is skipped for tables that have never been analyzed; run ANALYZE on them first."
+        "ALTER TABLE is skipped for tables that have never been analyzed; ANALYZE and VACUUM still run."
       );
     }
 
@@ -871,7 +879,7 @@ document.addEventListener("DOMContentLoaded", function () {
       vacuum: "Reclaim dead tuples on all flagged tables.",
       analyze: "Refresh planner statistics on all flagged tables.",
       alter: "Apply recommended per-table autovacuum settings on flagged tables with existing statistics.",
-      all: "Full maintenance pass: VACUUM, then ANALYZE, then ALTER TABLE tuning where statistics exist.",
+      all: "Full maintenance pass: ALTER TABLE tuning where statistics exist, then ANALYZE, then VACUUM.",
     };
 
     if (kind === "alter" && !statements.length) {
@@ -1075,9 +1083,15 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     if (!response.ok || !result.success) {
-      throw new Error(result.error || "Execution failed.");
+      throw new Error(result.error || result.message || "Execution failed.");
     }
 
+    return result;
+  }
+
+  function formatExecutionOutput(result) {
+    if (!result) return "OK";
+    if (result.output) return result.output;
     return result.message || "OK";
   }
 
@@ -1107,8 +1121,11 @@ document.addEventListener("DOMContentLoaded", function () {
       for (let index = 0; index < statements.length; index += 1) {
         const sql = statements[index];
         logs.push("[" + (index + 1) + "/" + statements.length + "] " + sql);
-        const message = await executeStatement(sql);
-        logs.push("Success: " + message);
+        const result = await executeStatement(sql);
+        const output = formatExecutionOutput(result);
+        if (output) {
+          logs.push(output);
+        }
       }
 
       const elapsedMs = Math.round(performance.now() - startedAt);

--- a/apps/templates/home/table_autovacuum_tune.html
+++ b/apps/templates/home/table_autovacuum_tune.html
@@ -185,8 +185,63 @@
     position: sticky;
     left: 0;
     z-index: 1;
-    min-width: 280px;
+    min-width: 240px;
+    max-width: 320px;
+    white-space: normal;
+    vertical-align: top;
     box-shadow: 1px 0 0 var(--pga-border-soft, #edf2f7);
+  }
+
+  .autovac-table-cell {
+    display: flex;
+    flex-direction: column;
+    gap: .55rem;
+    min-width: 0;
+  }
+
+  .autovac-table-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: .5rem;
+  }
+
+  .autovac-table-name {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .autovac-table-name .fw-semibold {
+    font-size: .86rem;
+    line-height: 1.3;
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+
+  .autovac-table-name .small.text-muted {
+    font-size: .76rem;
+    margin-top: .15rem;
+  }
+
+  .autovac-table .autovac-col-table .autovac-calc-btn {
+    width: 1.65rem;
+    height: 1.65rem;
+    padding: 0;
+    line-height: 1;
+    font-size: .72rem;
+    font-weight: 800;
+    border-radius: 999px;
+    border-color: #cbd5e1;
+    color: #475569;
+    background: #fff;
+    flex-shrink: 0;
+  }
+
+  .autovac-table .autovac-col-table .autovac-calc-btn:hover {
+    color: var(--pga-primary, #2f6f9f);
+    border-color: #93c5fd;
+    background: #eff6ff;
   }
 
   .autovac-table thead tr.autovac-colgroup-row .autovac-col-table {
@@ -221,8 +276,14 @@
   }
 
   .autovac-table .autovac-col-issue {
-    min-width: 210px;
-    max-width: 280px;
+    min-width: 220px;
+    white-space: normal;
+    vertical-align: top;
+  }
+
+  .autovac-col-issue .small.text-muted {
+    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .autovac-table .autovac-note {
@@ -320,61 +381,41 @@
     padding: .35em .55em;
   }
 
-  .autovac-row-toolbar {
-    display: flex;
-    align-items: center;
-    gap: .45rem;
-    flex-wrap: wrap;
-  }
-
-  .autovac-row-toolbar .autovac-calc-btn {
-    width: 1.65rem;
-    height: 1.65rem;
-    padding: 0;
-    line-height: 1;
-    font-size: .72rem;
-    font-weight: 800;
-    border-radius: 999px;
-    border-color: #cbd5e1;
-    color: #475569;
-    background: #fff;
-  }
-
-  .autovac-row-toolbar .autovac-calc-btn:hover {
-    color: var(--pga-primary, #2f6f9f);
-    border-color: #93c5fd;
-    background: #eff6ff;
-  }
-
   .autovac-row-actions {
-    display: inline-flex;
-    flex-wrap: nowrap;
-    gap: .25rem;
-    padding: .15rem;
-    border-radius: 999px;
-    background: #f1f5f9;
-    border: 1px solid #e2e8f0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .3rem;
+    align-items: center;
   }
 
   .autovac-row-actions .btn {
     white-space: nowrap;
-    border-radius: 999px !important;
+    border-radius: .45rem !important;
     font-size: .68rem;
     font-weight: 700;
-    padding: .2rem .55rem;
+    padding: .22rem .5rem;
     line-height: 1.2;
   }
 
-  .autovac-table-name {
-    min-width: 0;
-  }
-
-  .autovac-table-name .fw-semibold {
-    font-size: .86rem;
-    line-height: 1.25;
+  .autovac-row-actions .small.text-muted {
+    font-size: .68rem;
   }
 
   .autovac-actions .btn { white-space: nowrap; }
+
+  @media (max-width: 1199.98px) {
+    .autovac-table .autovac-col-table {
+      position: static;
+      box-shadow: none;
+      max-width: none;
+    }
+
+    .autovac-table thead tr.autovac-colgroup-row .autovac-col-table,
+    .autovac-table thead tr#autovac-header-row .autovac-col-table,
+    .autovac-table thead tr.autovac-filter-row .autovac-col-table {
+      z-index: 2;
+    }
+  }
 
   .autovac-global-table .autovac-table thead th { top: 0; }
   .autovac-global-table .autovac-table tbody td:first-child code {
@@ -1112,6 +1153,18 @@ document.addEventListener("DOMContentLoaded", function () {
       + "</div>";
   }
 
+  function renderTableCell(row, index) {
+    return '<div class="autovac-table-cell">'
+      + '<div class="autovac-table-head">'
+      + '<div class="autovac-table-name"><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
+      + '<div class="small text-muted">' + escapeHtml(row.table_size_pretty || "—") + '</div></div>'
+      + '<button type="button" class="btn btn-outline-secondary btn-sm autovac-calc-btn" '
+      + 'data-row-index="' + index + '" title="Show flagging and ALTER calculation" aria-label="Show calculation details">?</button>'
+      + '</div>'
+      + renderCommandsCell(row, index)
+      + '</div>';
+  }
+
   function bindCommandButtons() {
     document.querySelectorAll(".autovac-cmd-btn").forEach(function (button) {
       button.addEventListener("click", function () {
@@ -1163,12 +1216,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const neverAnalyzed = issueTypes.includes("never_analyzed");
       const neverVacuumed = issueTypes.includes("never_vacuumed");
       return '<tr class="autovac-data-row">'
-        + '<td class="autovac-col-table"><div class="autovac-row-toolbar">'
-        + '<button type="button" class="btn btn-outline-secondary btn-sm autovac-calc-btn flex-shrink-0" '
-        + 'data-row-index="' + index + '" title="Show flagging and ALTER calculation" aria-label="Show calculation details">?</button>'
-        + renderCommandsCell(row, index)
-        + '<div class="autovac-table-name"><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
-        + '<div class="small text-muted">' + escapeHtml(row.table_size_pretty || "—") + '</div></div></div></td>'
+        + '<td class="autovac-col-table">' + renderTableCell(row, index) + '</td>'
         + '<td class="autovac-note autovac-col-issue">' + renderIssueCell(row) + '</td>'
         + '<td>' + renderTimestampCell(row.last_analyze) + '</td>'
         + '<td>' + renderTimestampCell(row.last_autoanalyze) + '</td>'

--- a/apps/templates/home/table_autovacuum_tune.html
+++ b/apps/templates/home/table_autovacuum_tune.html
@@ -6,95 +6,394 @@
 <link rel="stylesheet" href="{{ config.ASSETS_ROOT }}/css/pgassistant.css">
 <style>
   .autovac-page { padding: 1.5rem; }
+
+  .autovac-table-card {
+    border: 1px solid var(--pga-border, #dfe7f1);
+    border-radius: var(--pga-radius-lg, 1.15rem);
+    background: var(--pga-surface, #fff);
+    box-shadow: var(--pga-shadow-sm, 0 6px 18px rgba(15, 23, 42, 0.06));
+    overflow: hidden;
+  }
+
+  .autovac-table-card-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--pga-border-soft, #edf2f7);
+    background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+  }
+
+  .autovac-table-card-header h2 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 850;
+    color: var(--pga-text, #172033);
+  }
+
   .autovac-table-scroll {
-    overflow-x: auto;
-    overflow-y: hidden;
-    border: 1px solid var(--bs-border-color, #dee2e6);
-    border-radius: .75rem;
-    margin-bottom: 1rem;
+    overflow: auto;
+    max-height: min(72vh, 920px);
     scrollbar-width: thin;
     scrollbar-color: #94a3b8 #f1f5f9;
   }
-  .autovac-table-scroll::-webkit-scrollbar { height: 10px; }
-  .autovac-table-scroll::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 999px; }
+
+  .autovac-table-scroll::-webkit-scrollbar { width: 10px; height: 10px; }
+  .autovac-table-scroll::-webkit-scrollbar-track { background: #f1f5f9; }
   .autovac-table-scroll::-webkit-scrollbar-thumb { background: #94a3b8; border-radius: 999px; }
+
   .autovac-table {
-    min-width: 1520px;
+    min-width: 1480px;
     margin-bottom: 0;
     font-size: .875rem;
-    color: var(--pga-text, #0f172a);
+    color: var(--pga-text, #172033);
+    border-collapse: separate;
+    border-spacing: 0;
   }
+
   .autovac-table thead th {
-    font-size: .78rem;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    font-size: .72rem;
     font-weight: 850;
-    letter-spacing: .04em;
+    letter-spacing: .05em;
     text-transform: uppercase;
     color: var(--pga-muted, #64748b);
-    background: #f8fafc !important;
-    border-bottom-color: #e8eef5;
+    background: #f8fafc;
+    border-bottom: 1px solid var(--pga-border, #dfe7f1);
+    box-shadow: inset 0 -1px 0 var(--pga-border, #dfe7f1);
   }
+
+  .autovac-table thead tr.autovac-colgroup-row th {
+    top: 0;
+    z-index: 3;
+    font-size: .68rem;
+    letter-spacing: .08em;
+    padding: .55rem .75rem;
+    border-bottom: 0;
+  }
+
+  .autovac-table thead tr#autovac-header-row th {
+    top: 2rem;
+    z-index: 2;
+    padding-top: .45rem;
+    padding-bottom: .55rem;
+  }
+
+  .autovac-table thead tr.autovac-filter-row th {
+    top: 4.1rem;
+    z-index: 2;
+    background: #fff;
+    border-top: 1px solid var(--pga-border-soft, #edf2f7);
+    padding-top: .45rem;
+    padding-bottom: .55rem;
+    vertical-align: top;
+  }
+
+  .autovac-colgroup-table { background: #eef2ff !important; color: #4338ca; }
+  .autovac-colgroup-analyze { background: #eff6ff !important; color: #1d4ed8; }
+  .autovac-colgroup-vacuum { background: #fff7ed !important; color: #c2410c; }
+  .autovac-colgroup-stats { background: #f0fdf4 !important; color: #15803d; }
+
   .autovac-table tbody td {
-    font-size: .875rem;
+    font-size: .84rem;
     color: #334155;
     font-variant-numeric: tabular-nums;
+    border-bottom: 1px solid var(--pga-border-soft, #edf2f7);
+    background: #fff;
   }
+
+  .autovac-table tbody tr.autovac-data-row:hover td {
+    background: #f8fbff;
+  }
+
+  .autovac-table tbody tr.autovac-data-row:nth-child(even) td {
+    background: #fcfdff;
+  }
+
+  .autovac-table tbody tr.autovac-data-row:nth-child(even):hover td {
+    background: #f1f7ff;
+  }
+
   .autovac-table tbody .fw-semibold {
     font-weight: 850;
-    color: var(--pga-text, #0f172a);
+    color: var(--pga-text, #172033);
   }
+
   .autovac-table tbody .small.text-muted {
-    font-size: .84rem;
+    font-size: .78rem;
     color: var(--pga-muted, #64748b);
   }
+
   .autovac-table th.sortable {
     cursor: pointer;
     user-select: none;
     white-space: nowrap;
+    transition: color .15s ease, background .15s ease;
   }
+
+  .autovac-table th.sortable:hover {
+    color: var(--pga-primary, #2f6f9f);
+    background: #eef6fc !important;
+  }
+
   .autovac-table th.sortable .sort-indicator {
-    font-size: .7rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1rem;
+    font-size: .65rem;
     color: #94a3b8;
-    margin-left: .2rem;
+    margin-left: .15rem;
   }
+
+  .autovac-table th.sortable.active {
+    color: var(--pga-primary-dark, #214f73);
+    background: #e8f3fb !important;
+  }
+
   .autovac-table th.sortable.active .sort-indicator {
-    color: #2563eb;
+    color: var(--pga-primary, #2f6f9f);
   }
+
   .autovac-table .autovac-col-filter {
-    min-width: 88px;
-    font-size: .72rem;
-    padding: .2rem .35rem;
+    min-width: 84px;
+    font-size: .75rem;
+    padding: .28rem .5rem;
+    border-radius: 999px;
+    border-color: var(--pga-border, #dfe7f1);
+    background: #f8fafc;
   }
-  .autovac-table thead tr.autovac-filter-row th {
+
+  .autovac-table .autovac-col-filter:focus {
     background: #fff;
-    border-top: 0;
-    padding-top: 0;
-    vertical-align: top;
+    border-color: #93c5fd;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, .12);
   }
+
   .autovac-table th,
   .autovac-table td {
     white-space: nowrap;
     vertical-align: middle;
+    padding: .65rem .75rem;
   }
+
+  .autovac-table .autovac-col-table {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    min-width: 280px;
+    box-shadow: 1px 0 0 var(--pga-border-soft, #edf2f7);
+  }
+
+  .autovac-table thead tr.autovac-colgroup-row .autovac-col-table {
+    z-index: 4;
+    background: #eef2ff !important;
+  }
+
+  .autovac-table thead tr#autovac-header-row .autovac-col-table {
+    z-index: 4;
+    background: #f8fafc !important;
+  }
+
+  .autovac-table thead tr.autovac-filter-row .autovac-col-table {
+    z-index: 4;
+    background: #fff !important;
+  }
+
+  .autovac-table tbody tr.autovac-data-row td.autovac-col-table {
+    background: #fff;
+  }
+
+  .autovac-table tbody tr.autovac-data-row:nth-child(even) td.autovac-col-table {
+    background: #fcfdff;
+  }
+
+  .autovac-table tbody tr.autovac-data-row:hover td.autovac-col-table {
+    background: #f8fbff;
+  }
+
+  .autovac-table tbody tr.autovac-data-row:nth-child(even):hover td.autovac-col-table {
+    background: #f1f7ff;
+  }
+
+  .autovac-table .autovac-col-issue {
+    min-width: 210px;
+    max-width: 280px;
+  }
+
   .autovac-table .autovac-note {
     white-space: normal;
-    min-width: 220px;
-    max-width: 320px;
+    line-height: 1.35;
   }
-  .autovac-actions,
+
+  .autovac-table .autovac-num {
+    text-align: right;
+    font-weight: 650;
+  }
+
+  .autovac-table .autovac-ts {
+    font-size: .78rem;
+    color: #475569;
+  }
+
+  .autovac-table .autovac-ts.is-empty {
+    color: #cbd5e1;
+    font-style: italic;
+  }
+
+  .autovac-age-pill,
+  .autovac-urgency-pill,
+  .autovac-dead-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: .25rem;
+    padding: .18rem .55rem;
+    border-radius: 999px;
+    font-size: .75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    border: 1px solid transparent;
+  }
+
+  .autovac-age-pill.is-fresh {
+    color: #166534;
+    background: #ecfdf5;
+    border-color: #bbf7d0;
+  }
+
+  .autovac-age-pill.is-warn {
+    color: #b45309;
+    background: #fffbeb;
+    border-color: #fde68a;
+  }
+
+  .autovac-age-pill.is-stale {
+    color: #b91c1c;
+    background: #fef2f2;
+    border-color: #fecaca;
+  }
+
+  .autovac-age-pill.is-unknown {
+    color: #64748b;
+    background: #f8fafc;
+    border-color: #e2e8f0;
+  }
+
+  .autovac-dead-pill.is-low {
+    color: #475569;
+    background: #f8fafc;
+    border-color: #e2e8f0;
+  }
+
+  .autovac-dead-pill.is-medium {
+    color: #b45309;
+    background: #fffbeb;
+    border-color: #fde68a;
+  }
+
+  .autovac-dead-pill.is-high {
+    color: #b91c1c;
+    background: #fef2f2;
+    border-color: #fecaca;
+  }
+
+  .autovac-urgency-pill.is-low { color: #166534; background: #ecfdf5; border-color: #bbf7d0; }
+  .autovac-urgency-pill.is-medium { color: #b45309; background: #fffbeb; border-color: #fde68a; }
+  .autovac-urgency-pill.is-high { color: #b91c1c; background: #fef2f2; border-color: #fecaca; }
+  .autovac-urgency-pill.is-unknown { color: #64748b; background: #f8fafc; border-color: #e2e8f0; }
+
+  .autovac-issue-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .3rem;
+    margin-bottom: .35rem;
+  }
+
+  .autovac-issue-badges .badge {
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .02em;
+    padding: .35em .55em;
+  }
+
+  .autovac-row-toolbar {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+    flex-wrap: wrap;
+  }
+
+  .autovac-row-toolbar .autovac-calc-btn {
+    width: 1.65rem;
+    height: 1.65rem;
+    padding: 0;
+    line-height: 1;
+    font-size: .72rem;
+    font-weight: 800;
+    border-radius: 999px;
+    border-color: #cbd5e1;
+    color: #475569;
+    background: #fff;
+  }
+
+  .autovac-row-toolbar .autovac-calc-btn:hover {
+    color: var(--pga-primary, #2f6f9f);
+    border-color: #93c5fd;
+    background: #eff6ff;
+  }
+
   .autovac-row-actions {
     display: inline-flex;
-    flex-wrap: wrap;
-    gap: .35rem;
-    align-items: center;
+    flex-wrap: nowrap;
+    gap: .25rem;
+    padding: .15rem;
+    border-radius: 999px;
+    background: #f1f5f9;
+    border: 1px solid #e2e8f0;
   }
-  .autovac-row-actions .btn,
+
+  .autovac-row-actions .btn {
+    white-space: nowrap;
+    border-radius: 999px !important;
+    font-size: .68rem;
+    font-weight: 700;
+    padding: .2rem .55rem;
+    line-height: 1.2;
+  }
+
+  .autovac-table-name {
+    min-width: 0;
+  }
+
+  .autovac-table-name .fw-semibold {
+    font-size: .86rem;
+    line-height: 1.25;
+  }
+
   .autovac-actions .btn { white-space: nowrap; }
+
+  .autovac-global-table .autovac-table thead th { top: 0; }
+  .autovac-global-table .autovac-table tbody td:first-child code {
+    font-size: .78rem;
+    color: #1e3a8a;
+    background: #eff6ff;
+    border: 1px solid #dbeafe;
+    border-radius: .45rem;
+    padding: .15rem .4rem;
+  }
+
   .autovac-risk-list {
     margin: 0;
     padding-left: 1.1rem;
     font-size: .84rem;
   }
+
   .autovac-risk-list li + li { margin-top: .35rem; }
+
   .autovac-exec-result {
     border-radius: .75rem;
     padding: .75rem .9rem;
@@ -104,6 +403,7 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
+
   .autovac-snippet {
     background: #0f172a;
     color: #e2e8f0;
@@ -114,6 +414,7 @@
     word-break: break-word;
     margin: 0;
   }
+
   .pagination-wrapper {
     display: flex;
     flex-wrap: wrap;
@@ -121,38 +422,47 @@
     justify-content: space-between;
     gap: .75rem;
     margin-top: .5rem;
+    padding: .85rem 1.25rem 1rem;
+    border-top: 1px solid var(--pga-border-soft, #edf2f7);
+    background: #fcfdff;
   }
+
   .pagination-info { color: #64748b; font-size: .875rem; }
   .pagination-controls { display: flex; flex-wrap: wrap; gap: .35rem; }
+
+  .autovac-toolbar-card {
+    border: 1px solid var(--pga-border, #dfe7f1);
+    border-radius: var(--pga-radius-md, .85rem);
+    background: #fff;
+    box-shadow: var(--pga-shadow-sm, 0 6px 18px rgba(15, 23, 42, 0.06));
+  }
+
   .criteria-help-toggle { cursor: pointer; }
   .criteria-help-body { font-size: .875rem; color: #475569; }
   .criteria-help-body ul { margin-bottom: .75rem; padding-left: 1.25rem; }
   .criteria-help-body li { margin-bottom: .35rem; }
-  .autovac-calc-btn {
-    width: 1.5rem;
-    height: 1.5rem;
-    padding: 0;
-    line-height: 1;
-    font-size: .75rem;
-    font-weight: 700;
-    border-radius: 999px;
-  }
+
   .autovac-calc-section + .autovac-calc-section {
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid #e2e8f0;
   }
+
   .autovac-calc-list {
     margin: 0;
     padding-left: 1.1rem;
     font-size: .875rem;
   }
+
   .autovac-calc-list li + li { margin-top: .3rem; }
+
   .autovac-calc-params {
     font-size: .875rem;
     margin: 0;
   }
+
   .autovac-calc-params dt { font-weight: 600; }
+
   .autovac-calc-formula {
     font-size: .84rem;
     background: #f8fafc;
@@ -160,6 +470,12 @@
     border-radius: .5rem;
     padding: .5rem .65rem;
     margin-bottom: .35rem;
+  }
+
+  .autovac-kpi-grid .card {
+    border: 1px solid var(--pga-border, #dfe7f1);
+    border-radius: var(--pga-radius-md, .85rem);
+    box-shadow: var(--pga-shadow-sm, 0 6px 18px rgba(15, 23, 42, 0.06));
   }
 </style>
 {% endblock stylesheets %}
@@ -243,9 +559,9 @@
       </div>
 
       {% if global_tuning.recommendations %}
-      <div class="autovac-table-scroll mb-3">
+      <div class="autovac-table-scroll autovac-global-table mb-3">
         <table class="table table-sm autovac-table mb-0">
-          <thead class="table-light">
+          <thead>
             <tr>
               <th>Parameter</th>
               <th>Current</th>
@@ -304,14 +620,14 @@
   {% endif %}
 
   {% if advisor_result.tables %}
-  <div class="row g-3 mb-4">
+  <div class="row g-3 mb-4 autovac-kpi-grid">
     <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Tables flagged</div><div class="h4 mb-0">{{ advisor_result.summary.total }}</div></div></div></div>
     <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Analyze issues</div><div class="h4 mb-0">{{ advisor_result.summary.never_analyzed + advisor_result.summary.stale_analyze }}</div><div class="small text-muted">{{ advisor_result.summary.never_analyzed }} never · {{ advisor_result.summary.stale_analyze }} stale</div></div></div></div>
     <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Vacuum issues</div><div class="h4 mb-0">{{ advisor_result.summary.never_vacuumed + advisor_result.summary.stale_vacuum }}</div><div class="small text-muted">{{ advisor_result.summary.never_vacuumed }} never · {{ advisor_result.summary.stale_vacuum }} stale</div></div></div></div>
     <div class="col-md-3"><div class="card"><div class="card-body"><div class="small text-muted">Threshold</div><div class="h4 mb-0">{{ stale_days }} d</div><div class="small text-muted">Analyze age · vacuum + dead pressure</div></div></div></div>
   </div>
 
-  <div class="card border-0 shadow-sm mb-3">
+  <div class="card border-0 shadow-sm mb-3 autovac-toolbar-card">
     <div class="card-body py-3">
       <div class="d-flex flex-wrap align-items-center gap-2">
         <span class="small text-muted me-1">Run all flagged tables ({{ advisor_result.summary.total }}):</span>
@@ -329,62 +645,73 @@
 
   {% include "includes/autovac_stale_days_form.html" %}
 
-  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-    <div class="d-flex align-items-center flex-wrap gap-2">
-      <label for="autovac-per-page" class="form-label mb-0 small text-muted">Rows per page</label>
-      <select id="autovac-per-page" class="form-select form-select-sm" style="width: auto;">
-        <option value="10">10</option>
-        <option value="25" selected>25</option>
-        <option value="50">50</option>
-        <option value="100">100</option>
-      </select>
-      <button type="button" class="btn btn-outline-secondary btn-sm" id="autovac-reset-filters">Reset filters</button>
-      <span class="small text-muted" id="autovac-visible-count"></span>
+  <div class="autovac-table-card mb-3">
+    <div class="autovac-table-card-header">
+      <div>
+        <h2>Flagged tables</h2>
+        <p class="small text-muted mb-0">Sort, filter, and run maintenance per table or in batch.</p>
+      </div>
+      <div class="d-flex align-items-center flex-wrap gap-2">
+        <label for="autovac-per-page" class="form-label mb-0 small text-muted">Rows</label>
+        <select id="autovac-per-page" class="form-select form-select-sm" style="width: auto;">
+          <option value="10">10</option>
+          <option value="25" selected>25</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="autovac-reset-filters">Reset filters</button>
+        <span class="small text-muted" id="autovac-visible-count"></span>
+      </div>
     </div>
-    <div class="small text-muted">Click column headers to sort · filter in the row below headers</div>
-  </div>
 
-  <div class="autovac-table-scroll">
-    <table class="table table-sm autovac-table align-middle">
-      <thead class="table-light">
-        <tr id="autovac-header-row">
-          <th class="sortable" data-sort-key="object_name">Table <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="issue">Issue <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="last_analyze">Last analyze <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="last_autoanalyze">Last autoanalyze <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="stats_age_days">Stats age <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="last_vacuum">Last vacuum <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="last_autovacuum">Last autovacuum <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="vacuum_age_days">Vacuum age <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="n_live_tup">Rows <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="n_dead_tup">Dead tuples <span class="sort-indicator"></span></th>
-          <th class="sortable" data-sort-key="vacuum_urgency">Vacuum urgency <span class="sort-indicator"></span></th>
-        </tr>
-        <tr class="autovac-filter-row">
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="object_name" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="issue" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_analyze" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autoanalyze" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="stats_age_days" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_vacuum" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autovacuum" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_age_days" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_live_tup" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_dead_tup" placeholder="Filter"></th>
-          <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_urgency" placeholder="Filter"></th>
-        </tr>
-      </thead>
-      <tbody id="autovac-table-body"></tbody>
-    </table>
-  </div>
+    <div class="autovac-table-scroll">
+      <table class="table table-sm autovac-table align-middle mb-0">
+        <thead>
+          <tr class="autovac-colgroup-row">
+            <th colspan="2" class="autovac-colgroup-table">Table</th>
+            <th colspan="3" class="autovac-colgroup-analyze">Analyze</th>
+            <th colspan="3" class="autovac-colgroup-vacuum">Vacuum</th>
+            <th colspan="3" class="autovac-colgroup-stats">Pressure</th>
+          </tr>
+          <tr id="autovac-header-row">
+            <th class="sortable autovac-col-table" data-sort-key="object_name">Table <span class="sort-indicator"></span></th>
+            <th class="sortable autovac-col-issue" data-sort-key="issue">Issue <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="last_analyze">Last analyze <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="last_autoanalyze">Last autoanalyze <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="stats_age_days">Stats age <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="last_vacuum">Last vacuum <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="last_autovacuum">Last autovacuum <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="vacuum_age_days">Vacuum age <span class="sort-indicator"></span></th>
+            <th class="sortable autovac-num" data-sort-key="n_live_tup">Rows <span class="sort-indicator"></span></th>
+            <th class="sortable autovac-num" data-sort-key="n_dead_tup">Dead tuples <span class="sort-indicator"></span></th>
+            <th class="sortable" data-sort-key="vacuum_urgency">Urgency <span class="sort-indicator"></span></th>
+          </tr>
+          <tr class="autovac-filter-row">
+            <th class="autovac-col-table"><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="object_name" placeholder="Filter table"></th>
+            <th class="autovac-col-issue"><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="issue" placeholder="Filter issue"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_analyze" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autoanalyze" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="stats_age_days" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_vacuum" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="last_autovacuum" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_age_days" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_live_tup" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="n_dead_tup" placeholder="Filter"></th>
+            <th><input type="text" class="form-control form-control-sm autovac-col-filter" data-filter-key="vacuum_urgency" placeholder="Filter"></th>
+          </tr>
+        </thead>
+        <tbody id="autovac-table-body"></tbody>
+      </table>
+    </div>
 
-  <div id="autovac-empty-filter" class="alert alert-light border d-none mb-3">
-    No table matches the current column filters.
-  </div>
+    <div id="autovac-empty-filter" class="alert alert-light border d-none mx-3 mb-3">
+      No table matches the current column filters.
+    </div>
 
-  <div id="autovac-pagination" class="pagination-wrapper">
-    <div id="autovac-pagination-info" class="pagination-info"></div>
-    <div id="autovac-pagination-controls" class="pagination-controls"></div>
+    <div id="autovac-pagination" class="pagination-wrapper">
+      <div id="autovac-pagination-info" class="pagination-info"></div>
+      <div id="autovac-pagination-controls" class="pagination-controls"></div>
+    </div>
   </div>
   {% elif advisor_result.tables is defined and not advisor_result.tables %}
   {% include "includes/autovac_stale_days_form.html" %}
@@ -399,6 +726,7 @@
 {% if advisor_result and advisor_result.ok and advisor_result.tables %}
 <script type="application/json" id="autovac-rows-json">{{ advisor_result.tables | tojson }}</script>
 <script type="application/json" id="autovac-batch-json">{{ advisor_result.batch_actions | tojson }}</script>
+<script type="application/json" id="autovac-config-json">{"stale_days": {{ stale_days | default(7) }} }</script>
 {% endif %}
 
 {% if advisor_result and advisor_result.ok and advisor_result.global_tuning and advisor_result.global_tuning.recommendations %}
@@ -474,9 +802,12 @@ document.addEventListener("DOMContentLoaded", function () {
   const rowsDataEl = document.getElementById("autovac-rows-json");
   const globalDataEl = document.getElementById("autovac-global-json");
   const batchDataEl = document.getElementById("autovac-batch-json");
+  const configDataEl = document.getElementById("autovac-config-json");
   const rowsData = rowsDataEl ? JSON.parse(rowsDataEl.textContent || "[]") : [];
   const globalData = globalDataEl ? JSON.parse(globalDataEl.textContent || "[]") : [];
   const batchData = batchDataEl ? JSON.parse(batchDataEl.textContent || "{}") : {};
+  const autovacConfig = configDataEl ? JSON.parse(configDataEl.textContent || "{}") : {};
+  const staleDaysThreshold = Number(autovacConfig.stale_days || 7);
   const tableBody = document.getElementById("autovac-table-body");
   const emptyFilter = document.getElementById("autovac-empty-filter");
   const visibleCount = document.getElementById("autovac-visible-count");
@@ -517,6 +848,67 @@ document.addEventListener("DOMContentLoaded", function () {
   function formatTimestamp(value) {
     if (value === null || value === undefined || value === "") return "—";
     return String(value).replace("T", " ").slice(0, 19);
+  }
+
+  function renderTimestampCell(value) {
+    const formatted = formatTimestamp(value);
+    const isEmpty = formatted === "—";
+    return '<span class="autovac-ts' + (isEmpty ? " is-empty" : "") + '">' + escapeHtml(formatted) + "</span>";
+  }
+
+  function agePillClass(days, neverFlag) {
+    if (neverFlag || days === null || days === undefined || days === "") return "is-unknown";
+    const numeric = Number(days);
+    if (Number.isNaN(numeric)) return "is-unknown";
+    if (numeric <= staleDaysThreshold * 0.5) return "is-fresh";
+    if (numeric <= staleDaysThreshold) return "is-warn";
+    return "is-stale";
+  }
+
+  function renderAgeCell(days, neverFlag) {
+    if (neverFlag || days === null || days === undefined || days === "") {
+      return '<span class="autovac-age-pill is-unknown">—</span>';
+    }
+    const pillClass = agePillClass(days, false);
+    return '<span class="autovac-age-pill ' + pillClass + '">' + escapeHtml(String(days)) + " d</span>";
+  }
+
+  function deadPillClass(nDead, nLive) {
+    const dead = Number(nDead || 0);
+    const live = Number(nLive || 0);
+    if (dead >= 100000) return "is-high";
+    if (dead >= 10000 && dead / Math.max(live, 1) >= 0.05) return "is-high";
+    if (dead >= 1000 || dead / Math.max(live + dead, 1) >= 0.02) return "is-medium";
+    return "is-low";
+  }
+
+  function renderDeadCell(nDead, nLive) {
+    const dead = Number(nDead || 0);
+    const live = Number(nLive || 0);
+    const ratio = live > 0 ? ((dead / live) * 100).toFixed(1) : null;
+    const pillClass = deadPillClass(dead, live);
+    let label = dead.toLocaleString();
+    if (ratio !== null && dead > 0) {
+      label += " · " + ratio + "%";
+    }
+    return '<span class="autovac-dead-pill ' + pillClass + '">' + escapeHtml(label) + "</span>";
+  }
+
+  function urgencyPillClass(value) {
+    if (value === null || value === undefined || value === "") return "is-unknown";
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) return "is-unknown";
+    if (numeric >= 75) return "is-high";
+    if (numeric >= 40) return "is-medium";
+    return "is-low";
+  }
+
+  function renderUrgencyCell(value) {
+    if (value === null || value === undefined || value === "") {
+      return '<span class="autovac-urgency-pill is-unknown">—</span>';
+    }
+    const pillClass = urgencyPillClass(value);
+    return '<span class="autovac-urgency-pill ' + pillClass + '">' + escapeHtml(String(value)) + "</span>";
   }
 
   function formatAge(value) {
@@ -619,13 +1011,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function renderIssueCell(row) {
     const badges = (row.issue_types || []).map(function (issue) {
-      if (issue === "never_analyzed") return '<span class="badge bg-danger-subtle text-danger me-1">Never analyzed</span>';
-      if (issue === "stale_analyze") return '<span class="badge bg-warning-subtle text-warning me-1">Stale stats</span>';
-      if (issue === "never_vacuumed") return '<span class="badge bg-danger-subtle text-danger me-1">Never vacuumed</span>';
-      if (issue === "stale_vacuum") return '<span class="badge bg-warning-subtle text-warning me-1">Stale vacuum</span>';
+      if (issue === "never_analyzed") return '<span class="badge bg-danger-subtle text-danger">Never analyzed</span>';
+      if (issue === "stale_analyze") return '<span class="badge bg-warning-subtle text-warning">Stale stats</span>';
+      if (issue === "never_vacuumed") return '<span class="badge bg-danger-subtle text-danger">Never vacuumed</span>';
+      if (issue === "stale_vacuum") return '<span class="badge bg-warning-subtle text-warning">Stale vacuum</span>';
       return "";
     }).join("");
-    return badges + '<div class="small text-muted mt-1">' + escapeHtml(row.recommendation_note || "") + "</div>";
+    const note = row.recommendation_note
+      ? '<div class="small text-muted mt-1">' + escapeHtml(row.recommendation_note) + "</div>"
+      : "";
+    return '<div class="autovac-issue-badges">' + badges + "</div>" + note;
   }
 
   function renderListItems(items) {
@@ -709,10 +1104,12 @@ document.addEventListener("DOMContentLoaded", function () {
   function renderCommandsCell(row, index) {
     const alterHtml = row.alter_available
       ? '<button type="button" class="btn btn-outline-primary btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="alter">Alter</button>'
-      : '<span class="small text-muted ms-1" title="' + escapeHtml(row.alter_skip_reason || "") + '">Alter N/A</span>';
-    return '<button type="button" class="btn btn-outline-success btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="analyze">Analyze</button>'
+      : '<span class="small text-muted px-1" title="' + escapeHtml(row.alter_skip_reason || "") + '">Alter N/A</span>';
+    return '<div class="autovac-row-actions">'
+      + '<button type="button" class="btn btn-outline-success btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="analyze">Analyze</button>'
       + '<button type="button" class="btn btn-outline-warning btn-sm autovac-cmd-btn" data-row-index="' + index + '" data-cmd="vacuum">Vacuum</button>'
-      + alterHtml;
+      + alterHtml
+      + "</div>";
   }
 
   function bindCommandButtons() {
@@ -762,23 +1159,26 @@ document.addEventListener("DOMContentLoaded", function () {
     tableBody.innerHTML = pageRows.map(function (entry) {
       const row = entry.row;
       const index = entry.index;
+      const issueTypes = row.issue_types || [];
+      const neverAnalyzed = issueTypes.includes("never_analyzed");
+      const neverVacuumed = issueTypes.includes("never_vacuumed");
       return '<tr class="autovac-data-row">'
-        + '<td><div class="d-flex align-items-start gap-2 flex-wrap">'
+        + '<td class="autovac-col-table"><div class="autovac-row-toolbar">'
         + '<button type="button" class="btn btn-outline-secondary btn-sm autovac-calc-btn flex-shrink-0" '
         + 'data-row-index="' + index + '" title="Show flagging and ALTER calculation" aria-label="Show calculation details">?</button>'
-        + '<div class="autovac-row-actions flex-shrink-0">' + renderCommandsCell(row, index) + '</div>'
-        + '<div><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
+        + renderCommandsCell(row, index)
+        + '<div class="autovac-table-name"><div class="fw-semibold">' + escapeHtml(row.object_name || "") + '</div>'
         + '<div class="small text-muted">' + escapeHtml(row.table_size_pretty || "—") + '</div></div></div></td>'
-        + '<td class="autovac-note">' + renderIssueCell(row) + '</td>'
-        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_analyze)) + '</td>'
-        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_autoanalyze)) + '</td>'
-        + '<td>' + escapeHtml(formatAge(row.stats_age_days)) + '</td>'
-        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_vacuum)) + '</td>'
-        + '<td class="small">' + escapeHtml(formatTimestamp(row.last_autovacuum)) + '</td>'
-        + '<td>' + escapeHtml(formatAge(row.vacuum_age_days)) + '</td>'
-        + '<td>' + escapeHtml(String(row.n_live_tup || 0)) + '</td>'
-        + '<td>' + escapeHtml(String(row.n_dead_tup || 0)) + '</td>'
-        + '<td>' + escapeHtml(String(row.vacuum_urgency ?? "—")) + '</td>'
+        + '<td class="autovac-note autovac-col-issue">' + renderIssueCell(row) + '</td>'
+        + '<td>' + renderTimestampCell(row.last_analyze) + '</td>'
+        + '<td>' + renderTimestampCell(row.last_autoanalyze) + '</td>'
+        + '<td>' + renderAgeCell(row.stats_age_days, neverAnalyzed) + '</td>'
+        + '<td>' + renderTimestampCell(row.last_vacuum) + '</td>'
+        + '<td>' + renderTimestampCell(row.last_autovacuum) + '</td>'
+        + '<td>' + renderAgeCell(row.vacuum_age_days, neverVacuumed) + '</td>'
+        + '<td class="autovac-num">' + escapeHtml(Number(row.n_live_tup || 0).toLocaleString()) + '</td>'
+        + '<td class="autovac-num">' + renderDeadCell(row.n_dead_tup, row.n_live_tup) + '</td>'
+        + '<td>' + renderUrgencyCell(row.vacuum_urgency) + '</td>'
         + '</tr>';
     }).join("");
 

--- a/apps/templates/home/table_health.html
+++ b/apps/templates/home/table_health.html
@@ -369,11 +369,12 @@ document.addEventListener("DOMContentLoaded", function () {
       }
 
       if (result.success) {
+        const output = result.output || result.message || "Query executed successfully.";
         if (maintenanceResult) {
           maintenanceResult.innerHTML =
             '<div class="text-success"><strong>Success</strong></div>' +
             '<div class="mt-2">' +
-            escapeHtml(result.message || "Query executed successfully.") +
+            escapeHtml(output) +
             '</div>';
         }
       } else {

--- a/apps/templates/home/tools.html
+++ b/apps/templates/home/tools.html
@@ -535,6 +535,7 @@
       {% endfor %}
 
       {% set dba_items = [
+        ('Table autovacuum tuning', '/table_autovacuum_tune.html', 'analyze autovacuum tuning', 'bi bi-sliders2', 'Per-table ANALYZE and autovacuum recommendations with configurable stale stats threshold.', ['analyze','autovacuum','maintenance','stats']),
         ('Tables Health', '/global/table_health', 'analyze autovacuum', 'bi bi-clipboard-data', 'Review table activity, dead tuples, statistics freshness, and recent maintenance.', ['analyze','planner','stats']),
         ('Database report', '/dba_report', 'report summary', 'bi bi-file-earmark-text', 'Generate a consolidated database report.', ['report','summary','health'])
       ] %}

--- a/apps/templates/home/topqueries.html
+++ b/apps/templates/home/topqueries.html
@@ -20,6 +20,7 @@
       <h1 class="pg-title">Query activity</h1>
       <p class="pg-subtitle">
         Inspect the most active statements captured by pg_stat_statements, then drill down into detailed metrics or launch query analysis.
+        {% if multi_db_filter %}<span class="d-block mt-1">Database filter: <strong>{{ active_db }}</strong></span>{% endif %}
       </p>
     </div>
 

--- a/apps/templates/includes/autovac_stale_days_form.html
+++ b/apps/templates/includes/autovac_stale_days_form.html
@@ -1,0 +1,21 @@
+<div class="card border-0 shadow-sm mb-3 autovac-stale-form-card">
+  <div class="card-body py-3">
+    <form method="POST" action="/table_autovacuum_tune.html" class="row g-2 g-lg-3 align-items-end">
+      {% if multi_db_filter %}<input type="hidden" name="db" value="{{ active_db }}">{% endif %}
+      <div class="col-12 col-md-4 col-lg-3">
+        <label for="stale_days" class="form-label mb-1">Stale statistics threshold (days)</label>
+        <input class="form-control form-control-sm" id="stale_days" name="stale_days" type="number" min="1" max="365"
+               value="{{ stale_days }}">
+      </div>
+      <div class="col-12 col-md-auto">
+        <button type="submit" class="btn btn-primary btn-sm">Analyze tables</button>
+      </div>
+      <div class="col-12">
+        <div class="form-text mb-0 small">
+          Default: 7 days. ANALYZE is flagged when manual or auto statistics are missing or older than this.
+          VACUUM is flagged only when dead tuple pressure is significant, not from an old vacuum date alone.
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/apps/templates/includes/db_connection_panel.html
+++ b/apps/templates/includes/db_connection_panel.html
@@ -1,0 +1,115 @@
+{% set panel_layout = panel_layout|default('sidebar') %}
+{% if session.get('db_host') and session.get('db_connected') %}
+{% if panel_layout == 'mobile' %}
+<div class="pga-mobile-db-bar d-lg-none" aria-label="Database connection">
+  <div class="pga-mobile-db-bar-top">
+    <div class="pga-mobile-db-status">
+      <span class="pga-conn-dot" aria-hidden="true"></span>
+      <span class="pga-mobile-db-status-text">Connected</span>
+      {% if session.get('version') %}
+      <span class="pga-mobile-db-pg">PG {{ session['version'] }}</span>
+      {% endif %}
+    </div>
+    <a href="/database.html" class="pga-mobile-db-settings-btn" title="Connection settings" aria-label="Connection settings">
+      <i class="bi bi-sliders" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <div class="pga-mobile-db-grid">
+    <div class="pga-mobile-db-chip" title="{{ session['db_host'] }}{% if session.get('db_port') %}:{{ session['db_port'] }}{% endif %}">
+      <i class="bi bi-hdd-network" aria-hidden="true"></i>
+      <span class="pga-mobile-db-chip-text">{{ session['db_host'] }}{% if session.get('db_port') %}:{{ session['db_port'] }}{% endif %}</span>
+    </div>
+    {% if session.get('db_user') %}
+    <div class="pga-mobile-db-chip" title="{{ session['db_user'] }}">
+      <i class="bi bi-person" aria-hidden="true"></i>
+      <span class="pga-mobile-db-chip-text">{{ session['db_user'] }}</span>
+    </div>
+    {% endif %}
+    {% if multi_db_filter and cluster_databases %}
+    <span class="pga-mobile-db-chip pga-mobile-db-chip-mode">
+      <i class="bi bi-layers" aria-hidden="true"></i>
+      Multi-db
+    </span>
+    {% endif %}
+  </div>
+
+  {% if multi_db_filter and cluster_databases %}
+  {% with filter_layout='mobile' %}
+  {% include "includes/multi_db_filter.html" %}
+  {% endwith %}
+  {% else %}
+  <div class="pga-mobile-db-name" title="{{ session['db_name'] }}">
+    <i class="bi bi-database" aria-hidden="true"></i>
+    <span>{{ session['db_name'] }}</span>
+  </div>
+  {% endif %}
+</div>
+{% else %}
+<li class="nav-item pga-sidebar-db-wrap d-none d-lg-block">
+  <div class="pga-sidebar-db-panel">
+    <div class="pga-sidebar-db-head">
+      <div class="pga-sidebar-db-status" title="Active PostgreSQL connection">
+        <span class="pga-conn-dot" aria-hidden="true"></span>
+        <span class="pga-sidebar-db-status-text">Connected</span>
+      </div>
+      {% if session.get('version') %}
+      <span class="pga-sidebar-db-pg-badge">PG {{ session['version'] }}</span>
+      {% endif %}
+    </div>
+
+    <div class="pga-sidebar-db-body">
+      <div class="pga-sidebar-db-meta">
+        <span class="pga-sidebar-db-label">
+          <i class="bi bi-hdd-network" aria-hidden="true"></i>
+          {% if multi_db_filter and cluster_databases %}Cluster{% else %}Host{% endif %}
+        </span>
+        <span class="pga-sidebar-db-value"
+              title="{{ session['db_host'] }}{% if session.get('db_port') %}:{{ session['db_port'] }}{% endif %}">
+          {{ session['db_host'] }}{% if session.get('db_port') %}:{{ session['db_port'] }}{% endif %}
+        </span>
+      </div>
+
+      {% if session.get('db_user') %}
+      <div class="pga-sidebar-db-meta">
+        <span class="pga-sidebar-db-label">
+          <i class="bi bi-person" aria-hidden="true"></i>
+          User
+        </span>
+        <span class="pga-sidebar-db-value" title="{{ session['db_user'] }}">{{ session['db_user'] }}</span>
+      </div>
+      {% endif %}
+
+      {% if multi_db_filter and cluster_databases %}
+      {% with filter_layout='sidebar' %}
+      {% include "includes/multi_db_filter.html" %}
+      {% endwith %}
+      {% else %}
+      <div class="pga-sidebar-db-meta">
+        <span class="pga-sidebar-db-label">
+          <i class="bi bi-database" aria-hidden="true"></i>
+          Database
+        </span>
+        <span class="pga-sidebar-db-static" title="{{ session['db_name'] }}">{{ session['db_name'] }}</span>
+      </div>
+      {% endif %}
+    </div>
+
+    {% if multi_db_filter and cluster_databases %}
+    <div class="pga-sidebar-db-foot">
+      <span class="pga-sidebar-db-mode-badge">
+        <i class="bi bi-layers" aria-hidden="true"></i>
+        Multi-database
+      </span>
+      <span class="pga-sidebar-db-count">{{ cluster_databases|length }} DB</span>
+    </div>
+    {% endif %}
+
+    <a href="/database.html" class="pga-sidebar-db-settings">
+      <i class="bi bi-sliders" aria-hidden="true"></i>
+      Connection settings
+    </a>
+  </div>
+</li>
+{% endif %}
+{% endif %}

--- a/apps/templates/includes/footer.html
+++ b/apps/templates/includes/footer.html
@@ -142,7 +142,7 @@
       <span class="pga-footer-pill">
         <i class="bi bi-tag"></i>
         <a class="pga-footer-link" href="https://github.com/beh74/pgassistant-community/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">
-        v 3.4.5
+        v 3.5.0
         </a>
       </span>
     </div>

--- a/apps/templates/includes/multi_db_filter.html
+++ b/apps/templates/includes/multi_db_filter.html
@@ -1,0 +1,17 @@
+{% if multi_db_filter and cluster_databases %}
+<div class="pga-multi-db-filter d-flex align-items-center flex-wrap gap-2">
+  <span class="small text-muted">Database</span>
+  <form method="GET" action="{{ request.path }}" class="d-flex align-items-center gap-2 mb-0">
+    {% for key, value in request.args.items() %}
+      {% if key != 'db' %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+      {% endif %}
+    {% endfor %}
+    <select class="form-select form-select-sm pga-multi-db-select" name="db" aria-label="Filter by database" onchange="this.form.submit()">
+      {% for db_name in cluster_databases %}
+      <option value="{{ db_name }}" {% if db_name == active_db %}selected{% endif %}>{{ db_name }}</option>
+      {% endfor %}
+    </select>
+  </form>
+</div>
+{% endif %}

--- a/apps/templates/includes/multi_db_filter.html
+++ b/apps/templates/includes/multi_db_filter.html
@@ -1,8 +1,10 @@
 {% if multi_db_filter and cluster_databases %}
-{% set filter_layout = layout|default('inline') %}
+{% set filter_layout = filter_layout|default('inline') %}
 <div class="pga-multi-db-filter pga-multi-db-filter--{{ filter_layout }}">
   {% if filter_layout == 'sidebar' %}
   <label class="pga-sidebar-db-label" for="pga-sidebar-db-select">Database</label>
+  {% elif filter_layout == 'mobile' %}
+  <label class="pga-mobile-db-select-label" for="pga-mobile-db-select">Database</label>
   {% else %}
   <span class="small text-muted">Database</span>
   {% endif %}
@@ -13,8 +15,8 @@
       {% endif %}
     {% endfor %}
     <select
-      class="form-select form-select-sm pga-multi-db-select"
-      id="{% if filter_layout == 'sidebar' %}pga-sidebar-db-select{% else %}pga-topnav-db-select{% endif %}"
+      class="form-select form-select-sm pga-multi-db-select{% if filter_layout == 'mobile' %} pga-multi-db-select--mobile{% endif %}"
+      id="{% if filter_layout == 'sidebar' %}pga-sidebar-db-select{% elif filter_layout == 'mobile' %}pga-mobile-db-select{% else %}pga-topnav-db-select{% endif %}"
       name="db"
       aria-label="Filter by database"
       onchange="this.form.submit()"

--- a/apps/templates/includes/multi_db_filter.html
+++ b/apps/templates/includes/multi_db_filter.html
@@ -1,13 +1,24 @@
 {% if multi_db_filter and cluster_databases %}
-<div class="pga-multi-db-filter d-flex align-items-center flex-wrap gap-2">
+{% set filter_layout = layout|default('inline') %}
+<div class="pga-multi-db-filter pga-multi-db-filter--{{ filter_layout }}">
+  {% if filter_layout == 'sidebar' %}
+  <label class="pga-sidebar-db-label" for="pga-sidebar-db-select">Database</label>
+  {% else %}
   <span class="small text-muted">Database</span>
-  <form method="GET" action="{{ request.path }}" class="d-flex align-items-center gap-2 mb-0">
+  {% endif %}
+  <form method="GET" action="{{ request.path }}" class="pga-multi-db-form mb-0">
     {% for key, value in request.args.items() %}
       {% if key != 'db' %}
       <input type="hidden" name="{{ key }}" value="{{ value }}">
       {% endif %}
     {% endfor %}
-    <select class="form-select form-select-sm pga-multi-db-select" name="db" aria-label="Filter by database" onchange="this.form.submit()">
+    <select
+      class="form-select form-select-sm pga-multi-db-select"
+      id="{% if filter_layout == 'sidebar' %}pga-sidebar-db-select{% else %}pga-topnav-db-select{% endif %}"
+      name="db"
+      aria-label="Filter by database"
+      onchange="this.form.submit()"
+    >
       {% for db_name in cluster_databases %}
       <option value="{{ db_name }}" {% if db_name == active_db %}selected{% endif %}>{{ db_name }}</option>
       {% endfor %}

--- a/apps/templates/includes/navigation.html
+++ b/apps/templates/includes/navigation.html
@@ -1,9 +1,16 @@
 <style>
-  .pga-topnav {
+  .pga-topnav-stack {
     position: sticky;
     top: 0;
     z-index: 1010;
-    margin: .75rem 1rem 1rem;
+    margin-bottom: .85rem;
+  }
+
+  .pga-topnav {
+    position: relative;
+    top: auto;
+    z-index: 1;
+    margin: .75rem 1rem 0;
     padding: .7rem .85rem;
     border: 1px solid rgba(148, 163, 184, .24);
     border-radius: 1.35rem;
@@ -12,6 +19,13 @@
     box-shadow: 0 18px 42px rgba(15, 23, 42, .08);
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px);
+  }
+
+  .pga-topnav-stack .pga-mobile-db-bar {
+    margin: 0 1rem;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-top: 1px solid rgba(56, 189, 248, .18);
   }
 
   .pga-topnav-inner {
@@ -149,9 +163,18 @@
   }
 
   @media (max-width: 991.98px) {
+    .pga-topnav-stack {
+      margin-bottom: .75rem;
+    }
+
     .pga-topnav {
-      margin: .5rem .75rem .85rem;
-      border-radius: 1.1rem;
+      margin: .5rem .75rem 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .pga-topnav-stack .pga-mobile-db-bar {
+      margin: 0 .75rem;
     }
 
     .pga-topnav-search {
@@ -167,6 +190,11 @@
   @media (max-width: 575.98px) {
     .pga-topnav {
       padding: .55rem;
+      margin: .5rem .5rem 0;
+    }
+
+    .pga-topnav-stack .pga-mobile-db-bar {
+      margin: 0 .5rem;
     }
 
     .pga-topnav-search .form-control {
@@ -176,6 +204,7 @@
   }
 </style>
 
+<div class="pga-topnav-stack">
 <nav class="navbar navbar-top navbar-expand navbar-dashboard pga-topnav" aria-label="Top navigation">
   <div class="container-fluid px-0">
     <div class="pga-topnav-inner" id="navbarSupportedContent">
@@ -248,3 +277,8 @@
     </div>
   </div>
 </nav>
+
+{% with panel_layout='mobile' %}
+{% include "includes/db_connection_panel.html" %}
+{% endwith %}
+</div>

--- a/apps/templates/includes/navigation.html
+++ b/apps/templates/includes/navigation.html
@@ -254,7 +254,19 @@
       </div>
 
       <div class="pga-topnav-right">
-        {% if session['db_host'] %}
+        {% if session.get('db_host') and session.get('db_connected') %}
+          {% if multi_db_filter and cluster_databases %}
+          <div class="pga-db-context d-none d-lg-inline-flex">
+            <span class="pga-db-context-icon" aria-hidden="true">
+              <i class="bi bi-collection"></i>
+            </span>
+            <span class="pga-db-context-text">
+              <span class="pga-db-context-label">Cluster</span>
+              <span class="pga-db-context-value">{{ session['db_host'] }}</span>
+            </span>
+          </div>
+          {% include "includes/multi_db_filter.html" %}
+          {% else %}
           <div class="pga-db-context d-none d-lg-inline-flex" title="{{ session['db_host'] }} : {{ session['db_name'] }}">
             <span class="pga-db-context-icon" aria-hidden="true">
               <i class="bi bi-database"></i>
@@ -266,6 +278,7 @@
               </span>
             </span>
           </div>
+          {% endif %}
         {% endif %}
 
         <div class="nav-item dropdown">

--- a/apps/templates/includes/navigation.html
+++ b/apps/templates/includes/navigation.html
@@ -70,57 +70,6 @@
     box-shadow: none;
   }
 
-  .pga-db-context {
-    display: inline-flex;
-    align-items: center;
-    gap: .65rem;
-    min-width: 0;
-    max-width: 46vw;
-    padding: .45rem .7rem .45rem .5rem;
-    border: 1px solid rgba(20, 184, 166, .22);
-    border-radius: 999px;
-    background: linear-gradient(135deg, rgba(236, 253, 245, .95), rgba(240, 249, 255, .85));
-    color: #0f172a;
-  }
-
-  .pga-db-context-icon {
-    width: 32px;
-    height: 32px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0 0 auto;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #14b8a6, #38bdf8);
-    color: #fff;
-    box-shadow: 0 8px 18px rgba(20, 184, 166, .26);
-  }
-
-  .pga-db-context-text {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    line-height: 1.05;
-  }
-
-  .pga-db-context-label {
-    font-size: .66rem;
-    font-weight: 800;
-    letter-spacing: .08em;
-    text-transform: uppercase;
-    color: #0f766e;
-  }
-
-  .pga-db-context-value {
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: .84rem;
-    font-weight: 800;
-    color: #0f172a;
-  }
-
   .pga-topnav-menu-btn {
     width: 42px;
     height: 42px;
@@ -213,10 +162,6 @@
     .pga-topnav-left {
       flex: 1 1 auto;
     }
-
-    .pga-db-context {
-      display: none;
-    }
   }
 
   @media (max-width: 575.98px) {
@@ -254,33 +199,6 @@
       </div>
 
       <div class="pga-topnav-right">
-        {% if session.get('db_host') and session.get('db_connected') %}
-          {% if multi_db_filter and cluster_databases %}
-          <div class="pga-db-context d-none d-lg-inline-flex">
-            <span class="pga-db-context-icon" aria-hidden="true">
-              <i class="bi bi-collection"></i>
-            </span>
-            <span class="pga-db-context-text">
-              <span class="pga-db-context-label">Cluster</span>
-              <span class="pga-db-context-value">{{ session['db_host'] }}</span>
-            </span>
-          </div>
-          {% include "includes/multi_db_filter.html" %}
-          {% else %}
-          <div class="pga-db-context d-none d-lg-inline-flex" title="{{ session['db_host'] }} : {{ session['db_name'] }}">
-            <span class="pga-db-context-icon" aria-hidden="true">
-              <i class="bi bi-database"></i>
-            </span>
-            <span class="pga-db-context-text">
-              <span class="pga-db-context-label">Connected database</span>
-              <span class="pga-db-context-value">
-                {{ session['db_host'] }} : <strong>{{ session['db_name'] }}</strong>
-              </span>
-            </span>
-          </div>
-          {% endif %}
-        {% endif %}
-
         <div class="nav-item dropdown">
           <a
             class="nav-link dropdown-toggle pga-topnav-menu-btn"

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -293,6 +293,16 @@
         </li>
 
         {# DBA Corner menu #}
+        <li class="nav-item nav-tooling {% if 'table_autovacuum_tune' in segment %}active{% endif %}">
+          <a href="/table_autovacuum_tune.html" class="nav-link" {% if 'table_autovacuum_tune' in segment %}aria-current="page"{% endif %}>
+            <div class="sidebar-icon me-2 icon-20">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sliders2" viewBox="0 0 16 16">
+                <path fill-rule="evenodd" d="M10.5 3a.5.5 0 0 0-.5-.5H1.5a.5.5 0 0 0 0 1H10a.5.5 0 0 0 .5-.5m0 4a.5.5 0 0 0-.5-.5H6.5a.5.5 0 0 0 0 1H10a.5.5 0 0 0 .5-.5M1.5 10.5a.5.5 0 0 0 0 1H10a.5.5 0 0 0 0-1H1.5a.5.5 0 0 0 0 1m10.5-6.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0m0 4a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0m0 4a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0"/>
+              </svg>
+            </div>
+            <div class="sidebar-text">Autovacuum tuning</div>
+          </a>
+        </li>
         <li class="nav-item nav-tooling {% if is_tools_dba %}active{% endif %}">
           <a href="/tools?cat=dba" class="nav-link" {% if is_tools_dba %}aria-current="page"{% endif %}>
             <div class="sidebar-icon me-2 icon-20">

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -100,6 +100,8 @@
         </a>
       </li>
 
+      {% include "includes/sidebar_db_context.html" %}
+
       {# ------------------- Top links (only if connected) ------------------- #}
       {% if session['db_host'] %}
       <li class="sidebar-section-label section-monitor">Monitor</li>

--- a/apps/templates/includes/sidebar_db_context.html
+++ b/apps/templates/includes/sidebar_db_context.html
@@ -1,0 +1,24 @@
+{% if session.get('db_host') and session.get('db_connected') %}
+<li class="nav-item pga-sidebar-db-wrap">
+  <div class="pga-sidebar-db-panel">
+    {% if multi_db_filter and cluster_databases %}
+    <div class="pga-sidebar-db-meta">
+      <span class="pga-sidebar-db-label">Cluster</span>
+      <span class="pga-sidebar-db-value" title="{{ session['db_host'] }}">{{ session['db_host'] }}</span>
+    </div>
+    {% with layout='sidebar' %}
+    {% include "includes/multi_db_filter.html" %}
+    {% endwith %}
+    {% else %}
+    <div class="pga-sidebar-db-meta">
+      <span class="pga-sidebar-db-label">Host</span>
+      <span class="pga-sidebar-db-value" title="{{ session['db_host'] }}">{{ session['db_host'] }}</span>
+    </div>
+    <div class="pga-sidebar-db-meta">
+      <span class="pga-sidebar-db-label">Database</span>
+      <span class="pga-sidebar-db-static" title="{{ session['db_name'] }}">{{ session['db_name'] }}</span>
+    </div>
+    {% endif %}
+  </div>
+</li>
+{% endif %}

--- a/apps/templates/includes/sidebar_db_context.html
+++ b/apps/templates/includes/sidebar_db_context.html
@@ -1,24 +1,3 @@
-{% if session.get('db_host') and session.get('db_connected') %}
-<li class="nav-item pga-sidebar-db-wrap">
-  <div class="pga-sidebar-db-panel">
-    {% if multi_db_filter and cluster_databases %}
-    <div class="pga-sidebar-db-meta">
-      <span class="pga-sidebar-db-label">Cluster</span>
-      <span class="pga-sidebar-db-value" title="{{ session['db_host'] }}">{{ session['db_host'] }}</span>
-    </div>
-    {% with layout='sidebar' %}
-    {% include "includes/multi_db_filter.html" %}
-    {% endwith %}
-    {% else %}
-    <div class="pga-sidebar-db-meta">
-      <span class="pga-sidebar-db-label">Host</span>
-      <span class="pga-sidebar-db-value" title="{{ session['db_host'] }}">{{ session['db_host'] }}</span>
-    </div>
-    <div class="pga-sidebar-db-meta">
-      <span class="pga-sidebar-db-label">Database</span>
-      <span class="pga-sidebar-db-static" title="{{ session['db_name'] }}">{{ session['db_name'] }}</span>
-    </div>
-    {% endif %}
-  </div>
-</li>
-{% endif %}
+{% with panel_layout='sidebar' %}
+{% include "includes/db_connection_panel.html" %}
+{% endwith %}

--- a/docker-compose/docker-compose.dev.yml
+++ b/docker-compose/docker-compose.dev.yml
@@ -1,0 +1,48 @@
+# Local development: builds from the repo and mounts source code.
+# Use this instead of docker-compose.yml when testing local changes.
+#
+#   cd docker-compose
+#   docker compose -f docker-compose.dev.yml up --build -d
+#
+# App: http://localhost:8080  (Connection page → Multi-database mode checkbox)
+
+services:
+  pgassistant:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: pgassistant-local:dev
+    container_name: pgassistant
+    restart: unless-stopped
+    ports:
+      - "8080:5005"
+    environment:
+      DEBUG: "True"
+    volumes:
+      - ../apps:/home/pgassistant/apps
+      - ../tests:/home/pgassistant/tests
+      - ../advisor_enriched.yml:/home/pgassistant/advisor_enriched.yml
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16
+    container_name: pgassistant-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgassistant_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgassistant_pgdata:

--- a/tests/test_analyze_advisor_helpers.py
+++ b/tests/test_analyze_advisor_helpers.py
@@ -21,6 +21,16 @@ def _load_helpers_module():
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
+
+    # Drop shim modules so later tests can import the real apps.home package.
+    for name in (
+        module_name,
+        "apps.home.database",
+        "apps.home",
+        "apps",
+    ):
+        sys.modules.pop(name, None)
+
     return module
 
 

--- a/tests/test_database_exec.py
+++ b/tests/test_database_exec.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import Mock
+
+from apps.home.database import format_sql_execution_output
+
+
+class DatabaseExecOutputTests(unittest.TestCase):
+    def test_format_sql_execution_output_with_rows(self):
+        cursor = Mock()
+        cursor.description = [("pg_reload_conf",)]
+        cursor.fetchall.return_value = [(True,)]
+        cursor.rowcount = 1
+
+        output = format_sql_execution_output(cursor, [])
+        self.assertIn("pg_reload_conf", output)
+        self.assertIn("True", output)
+
+    def test_format_sql_execution_output_with_notices(self):
+        cursor = Mock()
+        cursor.description = None
+        cursor.rowcount = -1
+
+        output = format_sql_execution_output(
+            cursor,
+            ["INFO:  vacuuming \"public.orders\"\n", "INFO:  finished vacuuming\n"],
+        )
+        self.assertIn('vacuuming "public.orders"', output)
+        self.assertIn("finished vacuuming", output)
+
+    def test_format_sql_execution_output_empty(self):
+        cursor = Mock()
+        cursor.description = None
+        cursor.rowcount = -1
+
+        self.assertEqual(format_sql_execution_output(cursor, []), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database_multi.py
+++ b/tests/test_database_multi.py
@@ -1,10 +1,14 @@
 import unittest
 
+from werkzeug.datastructures import ImmutableMultiDict
+
 from apps.home.database import (
     _uri_with_database,
     apply_pgss_database_filter,
     inject_pgss_current_db_filter,
+    resolve_db_config,
 )
+from apps.home.routes_helpers import _db_config_from_form
 
 
 class DatabaseMultiDbTests(unittest.TestCase):
@@ -47,6 +51,35 @@ class DatabaseMultiDbTests(unittest.TestCase):
     def test_inject_pgss_current_db_filter_skips_when_dbid_present(self):
         sql = "SELECT query FROM pg_stat_statements WHERE dbid = 123 ORDER BY 1"
         self.assertEqual(sql, inject_pgss_current_db_filter(sql))
+
+    def test_db_config_from_form_ignores_stale_active_db(self):
+        session_obj = {
+            "db_host": "old-host",
+            "db_port": "5432",
+            "db_name": "postgres",
+            "db_user": "postgres",
+            "db_password": "secret",
+            "multi_db": True,
+            "active_db": "legacy_app",
+            "cluster_databases": ["legacy_app", "legacy_other"],
+        }
+        form = ImmutableMultiDict(
+            [
+                ("db_host", "new-host"),
+                ("db_port", "5433"),
+                ("db_name", "appdb"),
+                ("db_user", "app"),
+                ("db_password", "newsecret"),
+                ("multi_db", "on"),
+            ]
+        )
+        merged = _db_config_from_form(form, session_obj)
+        self.assertNotIn("active_db", merged)
+        self.assertNotIn("cluster_databases", merged)
+        self.assertEqual(merged["db_host"], "new-host")
+        self.assertEqual(merged["db_name"], "appdb")
+        resolved = resolve_db_config(merged)
+        self.assertEqual(resolved["db_name"], "appdb")
 
 
 if __name__ == "__main__":

--- a/tests/test_database_multi.py
+++ b/tests/test_database_multi.py
@@ -1,0 +1,53 @@
+import unittest
+
+from apps.home.database import (
+    _uri_with_database,
+    apply_pgss_database_filter,
+    inject_pgss_current_db_filter,
+)
+
+
+class DatabaseMultiDbTests(unittest.TestCase):
+    def test_uri_with_database_replaces_existing_db(self):
+        uri = "postgresql://user:pass@localhost:5432/postgres?connect_timeout=5"
+        updated = _uri_with_database(uri, "northwind")
+        self.assertIn("/northwind", updated)
+
+    def test_inject_pgss_current_db_filter_before_order_by(self):
+        sql = (
+            "SELECT query FROM pg_stat_statements "
+            "WHERE calls > 0 ORDER BY total_exec_time DESC LIMIT 50"
+        )
+        filtered = inject_pgss_current_db_filter(sql)
+        self.assertIn("current_database()", filtered)
+        self.assertIn("ORDER BY total_exec_time DESC", filtered)
+        self.assertLess(filtered.index("current_database()"), filtered.index("ORDER BY"))
+
+    def test_apply_pgss_database_filter_uses_explicit_db_name(self):
+        sql = (
+            "SELECT query FROM pg_stat_statements "
+            "WHERE calls > 0 ORDER BY total_exec_time DESC LIMIT 50"
+        )
+        filtered = apply_pgss_database_filter(sql, "northwind")
+        self.assertIn("datname = 'northwind'", filtered)
+        self.assertLess(filtered.index("northwind"), filtered.index("ORDER BY"))
+
+    def test_apply_pgss_database_filter_appends_to_existing_where(self):
+        sql = "select query from pg_stat_statements where queryid=123"
+        filtered = apply_pgss_database_filter(sql, "appdb")
+        self.assertIn("where queryid=123", filtered.lower())
+        self.assertIn("datname = 'appdb'", filtered)
+
+    def test_uri_with_database_removes_dbname_query_param(self):
+        uri = "postgresql://user:pass@localhost:5432/postgres?dbname=postgres&connect_timeout=5"
+        updated = _uri_with_database(uri, "northwind")
+        self.assertIn("/northwind", updated)
+        self.assertNotIn("dbname=", updated)
+
+    def test_inject_pgss_current_db_filter_skips_when_dbid_present(self):
+        sql = "SELECT query FROM pg_stat_statements WHERE dbid = 123 ORDER BY 1"
+        self.assertEqual(sql, inject_pgss_current_db_filter(sql))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_table_autovacuum_advisor.py
+++ b/tests/test_table_autovacuum_advisor.py
@@ -34,7 +34,10 @@ class TableAutovacuumAdvisorTests(unittest.TestCase):
         self.assertEqual(build_analyze_sql("public", "orders"), 'ANALYZE "public"."orders";')
 
     def test_build_vacuum_sql(self):
-        self.assertEqual(build_vacuum_sql("public", "orders"), 'VACUUM "public"."orders";')
+        self.assertEqual(
+            build_vacuum_sql("public", "orders"),
+            'VACUUM VERBOSE "public"."orders";',
+        )
 
     def test_build_autovacuum_tuning_sql_large_table(self):
         sql = build_autovacuum_tuning_sql(
@@ -145,9 +148,9 @@ class TableAutovacuumAdvisorTests(unittest.TestCase):
         self.assertIn("risks", actions["vacuum"])
 
     def test_build_restore_script_without_alter(self):
-        sql = build_restore_script('ANALYZE "public"."t";', 'VACUUM "public"."t";', "")
+        sql = build_restore_script('ANALYZE "public"."t";', 'VACUUM VERBOSE "public"."t";', "")
         self.assertNotIn("Tune per-table", sql)
-        self.assertIn("ANALYZE", sql)
+        self.assertLess(sql.index("ANALYZE"), sql.index("VACUUM"))
 
     def test_build_criteria_help_includes_vacuum_pressure(self):
         help_doc = build_criteria_help(7)

--- a/tests/test_table_autovacuum_advisor.py
+++ b/tests/test_table_autovacuum_advisor.py
@@ -1,0 +1,221 @@
+import unittest
+
+from apps.home.table_autovacuum_advisor import (
+    _normalize_issue_types,
+    _primary_issue_type,
+    assess_cluster_load,
+    build_batch_actions,
+    build_analyze_sql,
+    build_autovacuum_tuning_sql,
+    build_criteria_help,
+    build_global_autovacuum_recommendations,
+    build_restore_script,
+    build_table_calculation_help,
+    build_tuning_rationale,
+    compute_autovacuum_tuning,
+    build_vacuum_sql,
+    get_batch_execution_risks,
+    get_execution_risks,
+    get_rule_sql,
+    normalize_stale_days,
+    render_rule_sql,
+)
+from apps.home.global_advisor import load_recommendation_catalog
+from pathlib import Path
+
+
+class TableAutovacuumAdvisorTests(unittest.TestCase):
+    def test_normalize_stale_days(self):
+        self.assertEqual(normalize_stale_days(None), 7)
+        self.assertEqual(normalize_stale_days("14"), 14)
+        self.assertEqual(normalize_stale_days(999), 365)
+
+    def test_build_analyze_sql(self):
+        self.assertEqual(build_analyze_sql("public", "orders"), 'ANALYZE "public"."orders";')
+
+    def test_build_vacuum_sql(self):
+        self.assertEqual(build_vacuum_sql("public", "orders"), 'VACUUM "public"."orders";')
+
+    def test_build_autovacuum_tuning_sql_large_table(self):
+        sql = build_autovacuum_tuning_sql(
+            "public",
+            "events",
+            n_live_tup=12_000_000,
+            n_dead_tup=800_000,
+            modified_since_analyze_ratio=0.4,
+            vacuum_urgency=2.5,
+            never_analyzed=True,
+        )
+        self.assertIn("autovacuum_analyze_scale_factor = 0.005", sql)
+        self.assertIn("autovacuum_vacuum_scale_factor = 0.005", sql)
+
+    def test_build_autovacuum_tuning_sql_many_dead_tuples(self):
+        sql = build_autovacuum_tuning_sql(
+            "public",
+            "logs",
+            n_live_tup=2_000_000,
+            n_dead_tup=1_500_000,
+            table_size_bytes=2 * 1024**3,
+        )
+        self.assertIn("autovacuum_vacuum_scale_factor = 0.005", sql)
+        self.assertIn("autovacuum_vacuum_threshold = 200", sql)
+
+    def test_build_tuning_rationale_dead_tuples(self):
+        rationale = build_tuning_rationale(
+            n_live_tup=12_000_000,
+            n_dead_tup=900_000,
+            table_size_bytes=20 * 1024**3,
+            vacuum_urgency=2.1,
+        )
+        self.assertIn("dead tuple", rationale.lower())
+        self.assertIn("critical", rationale.lower())
+
+    def test_assess_cluster_load_critical(self):
+        level = assess_cluster_load(
+            total_dead_tuples=12_000_000,
+            high_dead_pressure_tables=25,
+            critical_vacuum_count=6,
+            flagged_table_count=60,
+            active_autovacuum_workers=3,
+            current_max_workers=3,
+        )
+        self.assertEqual(level, "critical")
+
+    def test_build_global_autovacuum_recommendations_high_load(self):
+        result = build_global_autovacuum_recommendations(
+            load_level="high",
+            metrics={"user_table_count": 800, "total_dead_tuples": 2_000_000},
+            current_settings={
+                "autovacuum": {"setting": "on", "context": "sighup"},
+                "autovacuum_max_workers": {"setting": "3", "context": "postmaster"},
+                "autovacuum_naptime": {"setting": "60", "unit": "s", "context": "sighup"},
+                "autovacuum_vacuum_scale_factor": {"setting": "0.2", "context": "sighup"},
+                "autovacuum_analyze_scale_factor": {"setting": "0.1", "context": "sighup"},
+                "autovacuum_vacuum_threshold": {"setting": "50", "context": "sighup"},
+                "autovacuum_analyze_threshold": {"setting": "50", "context": "sighup"},
+                "autovacuum_vacuum_cost_delay": {"setting": "2", "unit": "ms", "context": "sighup"},
+                "autovacuum_vacuum_cost_limit": {"setting": "-1", "context": "sighup"},
+                "log_autovacuum_min_duration": {"setting": "-1", "context": "sighup"},
+                "max_worker_processes": {"setting": "16", "context": "postmaster"},
+            },
+        )
+        params = {item["parameter"] for item in result["recommendations"]}
+        self.assertIn("autovacuum_vacuum_scale_factor", params)
+        self.assertIn("autovacuum_max_workers", params)
+        self.assertIn("ALTER SYSTEM SET autovacuum_vacuum_scale_factor = 0.05;", result["script_sql"])
+        self.assertTrue(result["restart_required"])
+
+    def test_get_execution_risks_vacuum(self):
+        risks = get_execution_risks("vacuum", table_name="public.orders")
+        self.assertTrue(any("I/O" in risk for risk in risks))
+        self.assertTrue(any("public.orders" in risk for risk in risks))
+
+    def test_get_execution_risks_alter_system_postmaster(self):
+        risks = get_execution_risks(
+            "alter_system",
+            parameter="autovacuum_max_workers",
+            context="postmaster",
+        )
+        self.assertTrue(any("restart" in risk.lower() for risk in risks))
+
+    def test_primary_issue_type_prefers_vacuum(self):
+        self.assertEqual(
+            _primary_issue_type(["stale_analyze", "never_vacuumed"]),
+            "never_vacuumed",
+        )
+
+    def test_normalize_issue_types_pg_array(self):
+        self.assertEqual(
+            _normalize_issue_types("{never_vacuumed,stale_analyze}"),
+            ["never_vacuumed", "stale_analyze"],
+        )
+
+    def test_get_batch_execution_risks(self):
+        risks = get_batch_execution_risks("all", 12)
+        self.assertTrue(any("12 flagged table" in risk for risk in risks))
+        self.assertTrue(any("VACUUM" in risk for risk in risks))
+
+    def test_build_batch_actions(self):
+        actions = build_batch_actions([
+            {"object_name": "public.t1", "alter_available": False},
+            {"object_name": "public.t2", "alter_available": True},
+        ])
+        self.assertEqual(actions["table_count"], 2)
+        self.assertEqual(actions["alter_eligible_count"], 1)
+        self.assertIn("risks", actions["vacuum"])
+
+    def test_build_restore_script_without_alter(self):
+        sql = build_restore_script('ANALYZE "public"."t";', 'VACUUM "public"."t";', "")
+        self.assertNotIn("Tune per-table", sql)
+        self.assertIn("ANALYZE", sql)
+
+    def test_build_criteria_help_includes_vacuum_pressure(self):
+        help_doc = build_criteria_help(7)
+        self.assertEqual(help_doc["stale_days"], 7)
+        vacuum_section = next(s for s in help_doc["sections"] if s["id"] == "vacuum")
+        joined = " ".join(vacuum_section["points"])
+        self.assertIn("needs_vacuum_pressure", joined)
+        self.assertIn("10,000", joined)
+
+    def test_compute_autovacuum_tuning_includes_formulas(self):
+        tuning = compute_autovacuum_tuning(n_live_tup=2_000_000, n_dead_tup=150_000)
+        self.assertIn("vacuum_formula", tuning)
+        self.assertIn("analyze_formula", tuning)
+        self.assertGreater(tuning["vacuum_trigger_at"], 0)
+
+    def test_build_table_calculation_help_includes_alter_preview(self):
+        tuning = compute_autovacuum_tuning(n_live_tup=500_000, n_dead_tup=20_000)
+        help_doc = build_table_calculation_help(
+            stale_days=7,
+            issue_types=["stale_vacuum"],
+            never_vacuumed=False,
+            stale_vacuum=True,
+            needs_vacuum_pressure=True,
+            n_live_tup=500_000,
+            n_dead_tup=20_000,
+            alter_available=False,
+            alter_skip_reason="Run ANALYZE first.",
+            tuning=tuning,
+        )
+        self.assertTrue(help_doc["alter"]["preview_only"])
+        self.assertIn("vacuum_formula", help_doc["alter"])
+
+    def test_maintenance_flagged_sql_uses_vacuum_pressure(self):
+        catalog = load_recommendation_catalog(
+            str(Path(__file__).resolve().parents[1] / "advisor_enriched.yml")
+        )
+        sql = get_rule_sql(
+            catalog,
+            "table_autovacuum_maintenance_flagged",
+            stale_days=7,
+            min_table_size_bytes=1048576,
+        )
+        self.assertIn("needs_vacuum_pressure", sql)
+        self.assertIn("last_any_analyze", sql)
+
+    def test_render_rule_sql_replaces_parameters(self):
+        sql = render_rule_sql(
+            "SELECT {{stale_days}}::int, {{min_table_size_bytes}}::bigint;",
+            stale_days=14,
+            min_table_size_bytes=1048576,
+        )
+        self.assertIn("14::int", sql)
+        self.assertIn("1048576::bigint", sql)
+
+    def test_get_rule_sql_from_advisor_enriched(self):
+        yaml_path = Path(__file__).resolve().parents[1] / "advisor_enriched.yml"
+        catalog = load_recommendation_catalog(str(yaml_path))
+        sql = get_rule_sql(
+            catalog,
+            "table_autovacuum_maintenance_flagged",
+            stale_days=7,
+            min_table_size_bytes=1048576,
+        )
+        self.assertIn("never_vacuumed", sql)
+        self.assertIn("7::int AS stale_days", sql)
+        cluster_sql = get_rule_sql(catalog, "table_autovacuum_cluster_load")
+        self.assertIn("active_autovacuum_workers", cluster_sql)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add table autovacuum tuning page with flagging criteria, global ALTER SYSTEM recommendations, batch actions, and per-table calculation help (? modal)
- Add multi-database mode with DB filter in navigation and pg_stat_statements scoping per database
- Fix reconnect/generic_select edge cases and add unit tests

## Test plan
- [ ] Connect with multi-DB enabled and switch databases in navigation
- [ ] Open `/table_autovacuum_tune.html` and verify ? button shows flagging + ALTER calculation per table
- [ ] Run unit tests: `docker exec pgassistant bash -c "cd /home/pgassistant && PYTHONPATH=. python -m unittest discover -s tests -v"`
